### PR TITLE
New naming schema

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -37,6 +37,7 @@ export dprintln
 const TURING = Dict{Symbol, Any}()
 global sampler = nothing
 global debug_level = 0
+global CHUNKSIZE
 
 ##########
 # Helper #

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -1,5 +1,3 @@
-const CHUNKSIZE = 1000
-
 doc"""
     get_gradient_dict(spl :: GradientSampler)
 

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -83,7 +83,7 @@ macro assume(ex)
         )
       end
     )
-  elseif length(varExpr.args) == 2
+  elseif length(varExpr.args) == 2 && isa(varExpr.args[1], Symbol)
     esc(
       quote
         $(varExpr) = Turing.assume(
@@ -91,6 +91,22 @@ macro assume(ex)
           $(ex.args[3]),    # dDistribution
           VarInfo(          # Array assignment
             parse($(string(varExpr))),           # indexing expr
+            Symbol($(string(varExpr.args[2]))),  # index symbol
+            $(varExpr.args[2])                   # index value
+          )
+        )
+      end
+    )
+  elseif length(varExpr.args) == 2 && isa(varExpr.args[1], Expr)
+    esc(
+      quote
+        $(varExpr) = Turing.assume(
+          Turing.sampler,
+          $(ex.args[3]),    # dDistribution
+          VarInfo(          # Array assignment
+            parse($(string(varExpr))),           # indexing expr
+            Symbol($(string(varExpr.args[1].args[2]))),  # index symbol
+            $(varExpr.args[1].args[2]),                  # index value
             Symbol($(string(varExpr.args[2]))),  # index symbol
             $(varExpr.args[2])                   # index value
           )

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -70,28 +70,45 @@ macro assume(ex)
 
   # The if statement is to deterimnet how to pass the prior.
   # It only supposrts pure symbol and Array(/Dict) now.
-  if isa(ex.args[2], Symbol)
+  varExpr = ex.args[2]
+  if isa(varExpr, Symbol)
     esc(
       quote
-        $(ex.args[2]) = Turing.assume(
+        $(varExpr) = Turing.assume(
           Turing.sampler,
           $(ex.args[3]),    # dDistribution
           VarInfo(          # Pure Symbol
-            Symbol($(string(ex.args[2])))
+            Symbol($(string(varExpr)))
           )
         )
       end
     )
-  else
+  elseif length(varExpr.args) == 2
     esc(
       quote
-        $(ex.args[2]) = Turing.assume(
+        $(varExpr) = Turing.assume(
           Turing.sampler,
           $(ex.args[3]),    # dDistribution
           VarInfo(          # Array assignment
-            parse($(string(ex.args[2]))),           # indexing expr
-            Symbol($(string(ex.args[2].args[2]))),  # index symbol
-            $(ex.args[2].args[2])                   # index value
+            parse($(string(varExpr))),           # indexing expr
+            Symbol($(string(varExpr.args[2]))),  # index symbol
+            $(varExpr.args[2])                   # index value
+          )
+        )
+      end
+    )
+  elseif length(varExpr.args) == 3
+    esc(
+      quote
+        $(varExpr) = Turing.assume(
+          Turing.sampler,
+          $(ex.args[3]),    # dDistribution
+          VarInfo(          # Array assignment
+            parse($(string(varExpr))),           # indexing expr
+            Symbol($(string(varExpr.args[2]))),  # index symbol
+            $(varExpr.args[2]),                  # index value
+            Symbol($(string(varExpr.args[3]))),  # index symbol
+            $(varExpr.args[3])                   # index value
           )
         )
       end

--- a/src/core/gradientinfo.jl
+++ b/src/core/gradientinfo.jl
@@ -99,12 +99,22 @@ immutable VarInfo
     new(sym)
   end
   function VarInfo(arrExpr::Expr, idxSym::Symbol, idxVal::Any)
-    arrExpr
     if isa(arrExpr.args[2], Symbol)
       @assert arrExpr.args[2] == idxSym
       arrExpr.args[2] = idxVal
     end
     new(Symbol(arrExpr))
+  end
+  function VarInfo(matExpr::Expr, rowSym::Symbol, rowVal::Any, colSym::Symbol, colVal::Any)
+    if isa(matExpr.args[2], Symbol)
+      @assert matExpr.args[2] == rowSym
+      matExpr.args[2] = rowVal
+    end
+    if isa(matExpr.args[3], Symbol)
+      @assert matExpr.args[3] == colSym
+      matExpr.args[3] = colVal
+    end
+    new(Symbol(matExpr))
   end
 end
 

--- a/src/core/gradientinfo.jl
+++ b/src/core/gradientinfo.jl
@@ -125,7 +125,7 @@ immutable VarInfo
         mulDimExpr.args[2] = dim2Val
       end
     end
-    new(Symbol(mulDimExpr))
+    new(Symbol(replace(string(mulDimExpr), r"\(|\)", "")))
   end
 end
 

--- a/src/core/gradientinfo.jl
+++ b/src/core/gradientinfo.jl
@@ -96,14 +96,14 @@ strp = string(p)
 immutable VarInfo
   id    ::    Symbol
   function VarInfo(sym::Symbol)
-    new(sym)
+    new("T"*string(sym))
   end
   function VarInfo(arrExpr::Expr, idxSym::Symbol, idxVal::Any)
     if isa(arrExpr.args[2], Symbol)
       @assert arrExpr.args[2] == idxSym
       arrExpr.args[2] = idxVal
     end
-    new(Symbol(arrExpr))
+    new(Symbol("T"*string(arrExpr)))
   end
   function VarInfo(mulDimExpr::Expr, dim1Sym::Symbol, dim1Val::Any, dim2Sym::Symbol, dim2Val::Any)
     if isa(mulDimExpr.args[1], Symbol)    # mat form x[i, j]
@@ -125,7 +125,7 @@ immutable VarInfo
         mulDimExpr.args[2] = dim2Val
       end
     end
-    new(Symbol(mulDimExpr))
+    new(Symbol("T"*string(mulDimExpr)))
   end
 end
 

--- a/src/core/gradientinfo.jl
+++ b/src/core/gradientinfo.jl
@@ -105,16 +105,27 @@ immutable VarInfo
     end
     new(Symbol(arrExpr))
   end
-  function VarInfo(matExpr::Expr, rowSym::Symbol, rowVal::Any, colSym::Symbol, colVal::Any)
-    if isa(matExpr.args[2], Symbol)
-      @assert matExpr.args[2] == rowSym
-      matExpr.args[2] = rowVal
+  function VarInfo(mulDimExpr::Expr, dim1Sym::Symbol, dim1Val::Any, dim2Sym::Symbol, dim2Val::Any)
+    if isa(mulDimExpr.args[1], Symbol)    # mat form x[i, j]
+      if isa(mulDimExpr.args[2], Symbol)
+        @assert mulDimExpr.args[2] == dim1Sym
+        mulDimExpr.args[2] = dim1Val
+      end
+      if isa(mulDimExpr.args[3], Symbol)
+        @assert mulDimExpr.args[3] == dim2Sym
+        mulDimExpr.args[3] = dim2Val
+      end
+    elseif isa(mulDimExpr.args[1], Expr)  # multi array form x[i][j]
+      if isa(mulDimExpr.args[1], Expr)
+        @assert mulDimExpr.args[1].args[2] == dim1Sym
+        mulDimExpr.args[1].args[2] = dim1Val
+      end
+      if isa(mulDimExpr.args[2], Symbol)
+        @assert mulDimExpr.args[2] == dim2Sym
+        mulDimExpr.args[2] = dim2Val
+      end
     end
-    if isa(matExpr.args[3], Symbol)
-      @assert matExpr.args[3] == colSym
-      matExpr.args[3] = colVal
-    end
-    new(Symbol(matExpr))
+    new(Symbol(mulDimExpr))
   end
 end
 

--- a/src/core/gradientinfo.jl
+++ b/src/core/gradientinfo.jl
@@ -96,14 +96,14 @@ strp = string(p)
 immutable VarInfo
   id    ::    Symbol
   function VarInfo(sym::Symbol)
-    new("T"*string(sym))
+    new(sym)
   end
   function VarInfo(arrExpr::Expr, idxSym::Symbol, idxVal::Any)
     if isa(arrExpr.args[2], Symbol)
       @assert arrExpr.args[2] == idxSym
       arrExpr.args[2] = idxVal
     end
-    new(Symbol("T"*string(arrExpr)))
+    new(Symbol(arrExpr))
   end
   function VarInfo(mulDimExpr::Expr, dim1Sym::Symbol, dim1Val::Any, dim2Sym::Symbol, dim2Val::Any)
     if isa(mulDimExpr.args[1], Symbol)    # mat form x[i, j]
@@ -125,7 +125,7 @@ immutable VarInfo
         mulDimExpr.args[2] = dim2Val
       end
     end
-    new(Symbol("T"*string(mulDimExpr)))
+    new(Symbol(mulDimExpr))
   end
 end
 

--- a/src/core/gradientinfo.jl
+++ b/src/core/gradientinfo.jl
@@ -1,5 +1,7 @@
 export VarInfo, VarInfoArray, GradientInfo, addVarInfo
 
+########## VarInfoArray ##########
+
 doc"""
     VarInfoArray(array, count, currSetIdx, currGetIdx)
 
@@ -75,7 +77,7 @@ function get(pa::VarInfoArray)
   return pa.array[oldGetIdx]
 end
 
-
+########## VarInfo ##########
 
 doc"""
     VarInfo(sym)
@@ -92,13 +94,17 @@ strp = string(p)
 ```
 """
 immutable VarInfo
-  sym       ::    Symbol
-  name      ::    Symbol
-  function VarInfo(sym)
-    new(sym, :unknownname)
+  id    ::    Symbol
+  function VarInfo(sym::Symbol)
+    new(sym)
   end
-  function VarInfo(sym, name)
-    new(sym, name)
+  function VarInfo(arrExpr::Expr, idxSym::Symbol, idxVal::Any)
+    arrExpr
+    if isa(arrExpr.args[2], Symbol)
+      @assert arrExpr.args[2] == idxSym
+      arrExpr.args[2] = idxVal
+    end
+    new(Symbol(arrExpr))
   end
 end
 
@@ -108,10 +114,10 @@ doc"""
 Helper function to convert a VarInfo to its string representation.
 """
 function Base.string(p::VarInfo)
-  return string(p.sym)
+  return string(p.id)
 end
 
-
+########## GradientInfo ##########
 
 doc"""
     GradientInfo()

--- a/src/core/util.jl
+++ b/src/core/util.jl
@@ -63,7 +63,11 @@ end
 #####################################
 
 function realpart(d)
-  return map(x -> Float64(x.value), d)
+  if isa(d[1,1], Dual)      # matrix
+    return map(x -> Float64(x.value), d)
+  elseif isa(d[1,1], Array) # array of arry
+    return [map(x -> Float64(x.value), d[i]) for i in 1:length(d)]
+  end
 end
 
 function dualpart(d)

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -158,7 +158,8 @@ function predict(spl :: HMCSampler{HMC}, name :: Symbol, value)
   dprintln(2, "predict done")
 end
 
-function sample(model :: Function, alg :: HMC)
+function sample(model :: Function, alg :: HMC; chunk_size=1000)
   global sampler = HMCSampler{HMC}(alg, model);
+  global CHUNKSIZE = chunk_size;
   run(sampler)
 end

--- a/test/ad2.jl
+++ b/test/ad2.jl
@@ -1,0 +1,15 @@
+using Distributions
+using Turing
+using Base.Test
+
+# Define model
+@model ad_test begin
+  @assume s ~ InverseGamma(2,3)
+  @assume m ~ Normal(0,sqrt(s))
+  @observe 1.5 ~ Normal(m, sqrt(s))
+  @observe 2.0 ~ Normal(m, sqrt(s))
+  @predict s m
+end
+
+# Run HMC with chunk_size=1
+chain = sample(ad_test, HMC(1, 0.1, 1); chunk_size=1)

--- a/test/constrained_simplex.jl
+++ b/test/constrained_simplex.jl
@@ -12,7 +12,7 @@ obs = [1,2,1,2,2,2,2,2,2,2]
   @predict ps
 end
 
-chain = sample(constrained_simplex_test, HMC(2000, 0.75, 5))
+chain = sample(constrained_simplex_test, HMC(3000, 0.75, 5))
 println(mean(chain[:ps]))
 
 @test_approx_eq_eps mean(chain[:ps]) [5/16 11/16] 0.01

--- a/test/flaten_naming.jl
+++ b/test/flaten_naming.jl
@@ -6,15 +6,15 @@ using Base.Test
 
 # Symbol
 v_sym = VarInfo(:x)
-@test v_sym.id == :Tx
+@test v_sym.id == :x
 
 # Array
 v_arr = VarInfo(:(x[i]), :i, 1)
-@test v_arr.id == Symbol("T"*string(:(x[1])))
+@test v_arr.id == Symbol(:(x[1]))
 
 # Matrix
 v_mat = VarInfo(:(x[i,j]), :i, 1, :j, 2)
-@test v_mat.id == Symbol("T"*string(:(x[1,2])))
+@test v_mat.id == Symbol(:(x[1,2]))
 
 @model mat_name_test begin
   p = Array{Dual}((2, 2))
@@ -28,7 +28,7 @@ chain = sample(mat_name_test, HMC(2500, 0.75, 5))
 
 # Multi array
 v_arrarr = VarInfo(:(x[i][j]), :i, 1, :j, 2)
-@test v_arrarr.id == Symbol("T"*string(:((x[1])[2])))
+@test v_arrarr.id == Symbol(:((x[1])[2]))
 
 @model marr_name_test begin
   p = Array{Array{Dual}}(2)

--- a/test/flaten_naming.jl
+++ b/test/flaten_naming.jl
@@ -24,7 +24,7 @@ v_mat = VarInfo(:(x[i,j]), :i, 1, :j, 2)
   @predict p
 end
 chain = sample(mat_name_test, HMC(2500, 0.75, 5))
-@test_approx_eq_eps mean(mean(chain[:p])) 0 1e-2
+@test_approx_eq_eps mean(mean(chain[:p])) 0 5e-2
 
 # Multi array
 v_arrarr = VarInfo(:(x[i][j]), :i, 1, :j, 2)
@@ -40,4 +40,4 @@ v_arrarr = VarInfo(:(x[i][j]), :i, 1, :j, 2)
   @predict p
 end
 chain = sample(marr_name_test, HMC(2500, 0.75, 5))
-@test_approx_eq_eps mean(mean(mean(chain[:p]))) 0 1e-2
+@test_approx_eq_eps mean(mean(mean(chain[:p]))) 0 5e-2

--- a/test/flaten_naming.jl
+++ b/test/flaten_naming.jl
@@ -1,15 +1,33 @@
+using Distributions
+using ForwardDiff: Dual
+using Turing
 using Turing: VarInfo
 using Base.Test
 
+# Symbol
 v_sym = VarInfo(:x)
 @test v_sym.id == :x
 
+# Array
 v_arr = VarInfo(:(x[i]), :i, 1)
 @test v_arr.id == Symbol(:(x[1]))
 
+# Matrix
+v_mat = VarInfo(:(x[i,j]), :i, 1, :j, 2)
+@test v_mat.id == Symbol(:(x[1,2]))
+
+@model mat_name_test begin
+  p = Array{Dual}((2, 2))
+  for i in 1:2, j in 1:2
+    @assume p[i,j] ~ Normal(0, 1)
+  end
+  @predict p
+end
+chain = sample(mat_name_test, HMC(2500, 0.75, 5))
+@test_approx_eq_eps mean(mean(chain[:p])) 0 1e-2
+
 # TODO: implement below
-# v_mat = VarInfo(:(x[i,j]), :i, 1, :j, 2)
-# @test v_mat.id == :(x[1,2])
-#
+
+# Multi array
 # v_arrarr = VarInfo(:(x[i][j]), :i, 1, :j, 2)
 # @test v_arrarr.id == :(x[1][2])

--- a/test/flaten_naming.jl
+++ b/test/flaten_naming.jl
@@ -10,11 +10,11 @@ v_sym = VarInfo(:x)
 
 # Array
 v_arr = VarInfo(:(x[i]), :i, 1)
-@test v_arr.id == Symbol(:(x[1]))
+@test v_arr.id == Symbol("x[1]")
 
 # Matrix
 v_mat = VarInfo(:(x[i,j]), :i, 1, :j, 2)
-@test v_mat.id == Symbol(:(x[1,2]))
+@test v_mat.id == Symbol("x[1,2]")
 
 @model mat_name_test begin
   p = Array{Dual}((2, 2))
@@ -28,7 +28,7 @@ chain = sample(mat_name_test, HMC(2500, 0.75, 5))
 
 # Multi array
 v_arrarr = VarInfo(:(x[i][j]), :i, 1, :j, 2)
-@test v_arrarr.id == Symbol(:((x[1])[2]))
+@test v_arrarr.id == Symbol("x[1][2]")
 
 @model marr_name_test begin
   p = Array{Array{Dual}}(2)

--- a/test/flaten_naming.jl
+++ b/test/flaten_naming.jl
@@ -6,15 +6,15 @@ using Base.Test
 
 # Symbol
 v_sym = VarInfo(:x)
-@test v_sym.id == :x
+@test v_sym.id == :Tx
 
 # Array
 v_arr = VarInfo(:(x[i]), :i, 1)
-@test v_arr.id == Symbol(:(x[1]))
+@test v_arr.id == Symbol("T"*string(:(x[1])))
 
 # Matrix
 v_mat = VarInfo(:(x[i,j]), :i, 1, :j, 2)
-@test v_mat.id == Symbol(:(x[1,2]))
+@test v_mat.id == Symbol("T"*string(:(x[1,2])))
 
 @model mat_name_test begin
   p = Array{Dual}((2, 2))
@@ -28,7 +28,7 @@ chain = sample(mat_name_test, HMC(2500, 0.75, 5))
 
 # Multi array
 v_arrarr = VarInfo(:(x[i][j]), :i, 1, :j, 2)
-@test v_arrarr.id == Symbol(:((x[1])[2]))
+@test v_arrarr.id == Symbol("T"*string(:((x[1])[2])))
 
 @model marr_name_test begin
   p = Array{Array{Dual}}(2)

--- a/test/flaten_naming.jl
+++ b/test/flaten_naming.jl
@@ -1,0 +1,15 @@
+using Turing: VarInfo
+using Base.Test
+
+v_sym = VarInfo(:x)
+@test v_sym.id == :x
+
+v_arr = VarInfo(:(x[i]), :i, 1)
+@test v_arr.id == Symbol(:(x[1]))
+
+# TODO: implement below
+# v_mat = VarInfo(:(x[i,j]), :i, 1, :j, 2)
+# @test v_mat.id == :(x[1,2])
+#
+# v_arrarr = VarInfo(:(x[i][j]), :i, 1, :j, 2)
+# @test v_arrarr.id == :(x[1][2])

--- a/test/flaten_naming.jl
+++ b/test/flaten_naming.jl
@@ -26,8 +26,18 @@ end
 chain = sample(mat_name_test, HMC(2500, 0.75, 5))
 @test_approx_eq_eps mean(mean(chain[:p])) 0 1e-2
 
-# TODO: implement below
-
 # Multi array
-# v_arrarr = VarInfo(:(x[i][j]), :i, 1, :j, 2)
-# @test v_arrarr.id == :(x[1][2])
+v_arrarr = VarInfo(:(x[i][j]), :i, 1, :j, 2)
+@test v_arrarr.id == Symbol(:((x[1])[2]))
+
+@model marr_name_test begin
+  p = Array{Array{Dual}}(2)
+  p[1] = Array{Dual}(2)
+  p[2] = Array{Dual}(2)
+  for i in 1:2, j in 1:2
+    @assume p[i][j] ~ Normal(0, 1)
+  end
+  @predict p
+end
+chain = sample(marr_name_test, HMC(2500, 0.75, 5))
+@test_approx_eq_eps mean(mean(mean(chain[:p]))) 0 1e-2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ testcases = [
 #       graidnetinfo.jl
           "replay",
           "graidnetinfo",
+          "flaten_naming",
 #       IArray.jl
 #       intrinsic.jl
 #       io.jl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ testcases = [
 #     core/
 #       ad.jl
           "ad",
+          "ad2",
 #       compiler.jl
           "assume",
           "observe",

--- a/test/tarray3.jl
+++ b/test/tarray3.jl
@@ -6,6 +6,11 @@ push!(ta1, 1);
 push!(ta1, 2);
 @test pop!(ta1) == 2
 
+ta1_2 = TArray{Int, 1}(4); # another constructor
+push!(ta1_2, 1);
+push!(ta1_2, 2);
+@test pop!(ta1_2) == 2
+
 ta2 = TArray{Int}(4, 4);
 ta3 = TArray{Int, 4}(4, 3, 2, 1);
 ta4 = localcopy(ta3);
@@ -22,3 +27,5 @@ ta6 = TArray{Float64}(4);
 for i in 1:4 ta6[i] = i / 10 end
 @test ta6[1] == 0.1
 @test Array(ta6) == [0.1, 0.2, 0.3, 0.4]
+
+ta7 = TArray{Int, 2}((2, 2));   # TODO: add test for use this multi-dim array

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -2,7 +2,7 @@ using Turing: link, invlink
 using Base.Test
 using Distributions
 
-dists = [Beta(2,2), Dirichlet(2, 3), Wishart(7, [1 0.5; 0.5 1])]
+dists = [Arcsine(2, 4), Beta(2,2), Dirichlet(2, 3), Wishart(7, [1 0.5; 0.5 1])]
 
 for dist in dists
   x = rand(dist)    # sample


### PR DESCRIPTION
## New naming schema is implemented as below

```julia
      x ~ D # => :(x)
   x[i] ~ D # => :(x[1])
 x[i,j] ~ D # => :(x[1,2])
x[i][j] ~ D # => :(x[1][2])
```

## Other update

1. Support users' setting of chunk size via: `sample(model, HMC(...); chunk_size=...)`
2. More tests (for both old and new codes), making coverage back to 90%