### PR TITLE
Hmc space

### DIFF
--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -169,30 +169,8 @@ nextvn(vi::VarInfo, csym::Symbol, sym::Symbol, indexing::String) = begin
   VarName(csym, sym, indexing, 1)
 end
 
-# Main behaviour control of rand() depending on sampler type and if sampler inside
-rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::Sampler) = begin
-  local count
-
-  if isa(spl, HMCSampler{HMC})
-    count = false
-  elseif isa(spl, ParticleSampler{PG})
-    count = true
-  else
-    error("[rand]: unsupported sampler: $spl")
-  end
-
-  inside = isempty(spl.alg.space) || vn.sym in spl.alg.space ? true : false
-
-  if inside
-    randr(vi, vn, dist, spl.alg.group_id, spl, count)
-  else
-    randr(vi, vn, dist, 0, nothing, false)
-  end
-end
-
-# This method is called when sampler is Void
+# Default behaviour for Void
 rand(vi::VarInfo, vn::VarName, dist::Distribution) = randr(vi, vn, dist, 0, nothing, false)
-rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::Void) = rand(vi, vn, dist)
 
 # Random with replaying
 randr(vi::VarInfo, vn::VarName, dist::Distribution, gid=0, spl=nothing, count=false) = begin

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -189,7 +189,7 @@ randr(vi::VarInfo, vn::VarName, dist::Distribution, gid=0, spl=nothing, count=fa
   vi.index = count ? vi.index + 1 : vi.index
   local r
   if ~haskey(vi, vn)
-    r = rand(dist)
+    r = vectorize(dist, rand(dist)) # always store vector inside VarInfo
     addvar!(vi, vn, r, dist, gid)
     r
   else
@@ -202,7 +202,7 @@ randr(vi::VarInfo, vn::VarName, dist::Distribution, gid=0, spl=nothing, count=fa
       @assert uid_replay == uid(vn) "[randr] variable replayed doesn't match counting index"
     end
   end
-  r
+  reconstruct(dist, r)              # reconstruct from vector
 end
 
 # Randome with force overwriting by counter

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -93,8 +93,8 @@ getgid(vi::VarInfo, uid::Tuple) = vi.gids[getidx(vi, uid)]
 setgid!(vi::VarInfo, gid, vn::VarName) = vi.gids[getidx(vi, vn)] = gid
 setgid!(vi::VarInfo, gid, uid::Tuple) = vi.gids[getidx(vi, uid)] = gid
 
-gettrans(vi::VarInfo, vn::VarName) = vi.trans[getidx(vi, vn)]
-gettrans(vi::VarInfo, uid::Tuple) = vi.trans[getidx(vi, uid)]
+istransformed(vi::VarInfo, vn::VarName) = vi.trans[getidx(vi, vn)]
+istransformed(vi::VarInfo, uid::Tuple) = vi.trans[getidx(vi, uid)]
 settrans!(vi::VarInfo, trans, vn::VarName) = vi.trans[getidx(vi, vn)] = trans
 settrans!(vi::VarInfo, trans, uid::Tuple) = vi.trans[getidx(vi, uid)] = trans
 
@@ -209,7 +209,7 @@ randr(vi::VarInfo, vn::VarName, dist::Distribution, gid=0, spl=nothing, count=fa
     if ~(spl == nothing || isempty(spl.alg.space)) && getgid(vi, vn) == 0 && getsym(vi, vn) in spl.alg.space
       setgid!(vi, gid, vn)
     end
-    if gettrans(vi, vn)
+    if istransformed(vi, vn)
       invlink(dist, reconstruct(dist, vi[vn]))
     else
       reconstruct(dist, vi[vn])

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -170,7 +170,7 @@ nextvn(vi::VarInfo, csym::Symbol, sym::Symbol, indexing::String) = begin
 end
 
 # Main behaviour control of rand() depending on sampler type and if sampler inside
-rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::Sampler, inside=true) = begin
+rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::Sampler) = begin
   local count
 
   if isa(spl, HMCSampler{HMC})
@@ -181,6 +181,8 @@ rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::Sampler, inside=true) = 
     error("[rand]: unsupported sampler: $spl")
   end
 
+  inside = isempty(spl.alg.space) || vn.sym in spl.alg.space ? true : false
+
   if inside
     randr(vi, vn, dist, spl.alg.group_id, spl, count)
   else
@@ -189,9 +191,8 @@ rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::Sampler, inside=true) = 
 end
 
 # This method is called when sampler is Void
-rand(vi::VarInfo, vn::VarName, dist::Distribution) = begin
-  randr(vi, vn, dist, 0, nothing, false)
-end
+rand(vi::VarInfo, vn::VarName, dist::Distribution) = randr(vi, vn, dist, 0, nothing, false)
+rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::Void) = rand(vi, vn, dist)
 
 # Random with replaying
 randr(vi::VarInfo, vn::VarName, dist::Distribution, gid=0, spl=nothing, count=false) = begin

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -139,10 +139,8 @@ end
 function assume(spl::HMCSampler{HMC}, dist::Distribution, vn::VarName, vi::VarInfo)
   # Step 1 - Generate or replay variable
   dprintln(2, "assuming...")
-  inside = isempty(spl.alg.space) || vn.sym in spl.alg.space ? true : false
-  r = rand(vi, vn, dist, spl, inside)
-  trans = istransformed(vi, vn)
-  vi.logjoint += logpdf(dist, r, trans)
+  r = rand(vi, vn, dist, spl)
+  vi.logjoint += logpdf(dist, r, istransformed(vi, vn))
   r
 end
 

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -154,3 +154,5 @@ function observe(spl::Union{Void, HMCSampler{HMC}}, d::Distribution, value, vi::
   end
   dprintln(2, "observe done")
 end
+
+rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::HMCSampler{HMC}) = isempty(spl.alg.space) || vn.sym in spl.alg.space ? randr(vi, vn, dist, spl.alg.group_id, spl, false) : randr(vi, vn, dist)

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -141,7 +141,7 @@ function assume(spl::HMCSampler{HMC}, dist::Distribution, vn::VarName, vi::VarIn
   dprintln(2, "assuming...")
   inside = isempty(spl.alg.space) || vn.sym in spl.alg.space ? true : false
   r = rand(vi, vn, dist, spl, inside)
-  trans = gettrans(vi, vn)
+  trans = istransformed(vi, vn)
   vi.logjoint += logpdf(dist, r, trans)
   r
 end

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -66,9 +66,12 @@ function step(model, spl::Sampler{HMC}, varInfo::VarInfo, is_first::Bool)
 
     dprintln(2, "sampling momentum...")
     p = Dict(uid(k) => randn(length(varInfo[k])) for k in keys(varInfo))
-    if spl != nothing && ~isempty(spl.alg.space)
+    if ~isempty(spl.alg.space)
       p = filter((k, p) -> getsym(varInfo, k) in spl.alg.space, p)
     end
+
+    dprintln(3, "X -> R...")
+    varInfo = link(varInfo, spl)
 
     dprintln(2, "recording old H...")
     oldH = find_H(p, model, varInfo, spl)
@@ -83,6 +86,9 @@ function step(model, spl::Sampler{HMC}, varInfo::VarInfo, is_first::Bool)
 
     dprintln(2, "computing new H...")
     H = find_H(p, model, varInfo, spl)
+
+    dprintln(3, "R -> X...")
+    varInfo = invlink(varInfo, spl)
 
     dprintln(2, "computing ΔH...")
     ΔH = H - oldH
@@ -133,15 +139,10 @@ end
 function assume(spl::HMCSampler{HMC}, dist::Distribution, vn::VarName, vi::VarInfo)
   # Step 1 - Generate or replay variable
   dprintln(2, "assuming...")
-  local r
-  if spl == nothing || isempty(spl.alg.space) || vn.sym in spl.alg.space
-    r = rand(vi, vn, dist, spl)
-    vi.logjoint += logpdf(dist, r, true)
-  else
-    r = rand(vi, vn, dist, spl, false)
-    # Observe data, non-transformed variable
-    vi.logjoint += logpdf(dist, r, false)
-  end
+  inside = isempty(spl.alg.space) || vn.sym in spl.alg.space ? true : false
+  r = rand(vi, vn, dist, spl, inside)
+  trans = gettrans(vi, vn)
+  vi.logjoint += logpdf(dist, r, trans)
   r
 end
 

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -60,18 +60,7 @@ function step(model, spl::Sampler{PG}, vi, ref_particle)
   ref_particle, s
 end
 
-function assume(spl::ParticleSampler{PG}, dist::Distribution, vn::VarName, vi::VarInfo)
-  vi = current_trace().vi
-  local r
-  if isempty(spl.alg.space) || vn.sym in spl.alg.space
-    r = rand(vi, vn, dist, spl)
-  else
-    r = rand(vi, vn, dist, spl, false)
-    produce(log(1.0))
-  end
-  r
-end
-
+assume(spl::ParticleSampler{PG}, dist::Distribution, vn::VarName, vi::VarInfo) = rand(current_trace().vi, vn, dist, spl)
 
 function sample(model, alg::PG)
   global sampler = ParticleSampler{PG}(alg);

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -82,3 +82,5 @@ function sample(model, alg::PG)
   println("[PG]: Finshed within $(time() - t_start) seconds")
   chain = Chain(exp(mean(logevidence)), samples)
 end
+
+rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::ParticleSampler{PG}) = isempty(spl.alg.space) || vn.sym in spl.alg.space ? randr(vi, vn, dist, spl.alg.group_id, spl, true) : randr(vi, vn, dist)

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -48,18 +48,12 @@ predict(spl, var_name :: Symbol, value) =
   error("[predict]: unmanaged inference algorithm: $(typeof(spl))")
 
 function assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo)
-  r = rand(vi, vn, dist)
-  trans = istransformed(vi, vn)
-  vi.logjoint += logpdf(dist, r, trans)
+  r = rand(vi, vn, dist, spl)
+  vi.logjoint += logpdf(dist, r, istransformed(vi, vn))
   r
 end
 
 predict(spl::Void, var_name :: Symbol, value) = nothing
-
-rand(vi::VarInfo, vn::VarName, dist::Distribution, spl:: Void) = begin
-  # NOTE: Void sampler uses replaying by name method by default
-  rand(vi, vn, dist, :byname)
-end
 
 function sample(model::Function, data::Dict, alg::InferenceAlgorithm)
   global sampler = ParticleSampler{typeof(alg)}(model, alg);

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -49,7 +49,8 @@ predict(spl, var_name :: Symbol, value) =
 
 function assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo)
   r = rand(vi, vn, dist)
-  vi.logjoint += logpdf(dist, r, true)
+  trans = gettrans(vi, vn)
+  vi.logjoint += logpdf(dist, r, trans)
   r
 end
 

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -49,7 +49,7 @@ predict(spl, var_name :: Symbol, value) =
 
 function assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo)
   r = rand(vi, vn, dist)
-  trans = gettrans(vi, vn)
+  trans = istransformed(vi, vn)
   vi.logjoint += logpdf(dist, r, trans)
   r
 end

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -65,3 +65,6 @@ assume(spl::ParticleSampler, dist::Distribution, vn::VarName, vi)  = rand(curren
 observe(spl :: ParticleSampler, d :: Distribution, value, varInfo) = produce(logpdf(d, value))
 
 predict(spl :: Sampler, v_name :: Symbol, value) = nothing
+
+# This method is called when sampler is Void
+rand(vi::VarInfo, vn::VarName, dist::Distribution, spl::Void) = rand(vi, vn, dist)

--- a/src/samplers/support/helper.jl
+++ b/src/samplers/support/helper.jl
@@ -68,11 +68,7 @@ function link(vi, spl)
   end
   for k in gkeys
     dist = getdist(vi, k)
-    val_vec = vi[k]
-    new_vec = vectorize(dist, link(dist, reconstruct(dist, val_vec)))
-    for i = 1:length(val_vec)
-      val_vec[i] = new_vec[i]
-    end
+    vi[k] = vectorize(dist, link(dist, reconstruct(dist, vi[k])))
     settrans!(vi, true, k)
   end
   vi
@@ -86,11 +82,7 @@ function invlink(vi, spl)
   end
   for k in gkeys
     dist = getdist(vi, k)
-    val_vec = vi[k]
-    new_vec = vectorize(dist, invlink(dist, reconstruct(dist, val_vec)))
-    for i = 1:length(val_vec)
-      val_vec[i] = new_vec[i]
-    end
+    vi[k] = vectorize(dist, invlink(dist, reconstruct(dist, vi[k])))
     settrans!(vi, false, k)
   end
   vi

--- a/src/samplers/support/helper.jl
+++ b/src/samplers/support/helper.jl
@@ -51,15 +51,8 @@ export realpart, dualpart, make_dual, vectorize, reconstruct
 function varInfo2samples(vi)
   samples = Dict{Symbol, Any}()
   for uid in keys(vi)
-    val = vi[uid]
-    if istrans(vi, uid)
-      dist = getdist(vi, uid)
-      val = reconstruct(dist, val)
-      val = invlink(dist, val)
-      val = Any[realpart(val)]
-      val = length(val) == 1 ? val[1] : val   # Remove un-necessary []'s
-    end
-    samples[sym(uid)] = val
+    dist = getdist(vi, uid)
+    samples[sym(uid)] = realpart(reconstruct(dist, vi[uid]))
   end
   samples
 end

--- a/src/samplers/support/helper.jl
+++ b/src/samplers/support/helper.jl
@@ -54,7 +54,7 @@ function varInfo2samples(vi)
   for uid in keys(vi)
     dist = getdist(vi, uid)
     r = reconstruct(dist, vi[uid])
-    r = gettrans(vi, uid) ? invlink(dist, r) : r
+    r = istransformed(vi, uid) ? invlink(dist, r) : r
     samples[sym(uid)] = realpart(r)
   end
   samples

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -18,7 +18,19 @@ function leapfrog(values, val∇E, p, ϵ, model, spl)
 
   p = half_momentum_step(p, ϵ, val∇E) # half step for momentum
   for k in keys(val∇E)                # full step for state
-    values[k] = Vector{Dual}(values[k] + ϵ * p[k])
+    dist = getdist(values, k)
+    val_vec = values[k]
+    val = reconstruct(dist, val_vec)
+    val_real = link(dist, val)
+    val_real_vec = vectorize(dist, val_real)
+
+    new_val_real_vec = val_real_vec + ϵ * p[k]
+
+    new_val_real = reconstruct(dist, new_val_real_vec)
+    new_val = invlink(dist, new_val_real)
+    new_val_vec = vectorize(dist, new_val)
+
+    values[k] = new_val_vec
   end
   val∇E = gradient(values, model, spl)
   p = half_momentum_step(p, ϵ, val∇E) # half step for momentum

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -18,19 +18,8 @@ function leapfrog(values, val∇E, p, ϵ, model, spl)
 
   p = half_momentum_step(p, ϵ, val∇E) # half step for momentum
   for k in keys(val∇E)                # full step for state
-    dist = getdist(values, k)
-    val_vec = values[k]
-    val = reconstruct(dist, val_vec)
-    val_real = link(dist, val)
-    val_real_vec = vectorize(dist, val_real)
-
-    new_val_real_vec = val_real_vec + ϵ * p[k]
-
-    new_val_real = reconstruct(dist, new_val_real_vec)
-    new_val = invlink(dist, new_val_real)
-    new_val_vec = vectorize(dist, new_val)
-
-    values[k] = new_val_vec
+    # NOTE: Vector{Dual} is necessary magic conversion
+    values[k] = Vector{Dual}(values[k] + ϵ * p[k])
   end
   val∇E = gradient(values, model, spl)
   p = half_momentum_step(p, ϵ, val∇E) # half step for momentum

--- a/src/trace/trace.jl
+++ b/src/trace/trace.jl
@@ -75,7 +75,7 @@ typealias TraceR Trace{:R} # Task Copy
 typealias TraceC Trace{:C} # Replay
 
 # generate a new random variable, replay if t.counter < length(t.randomness)
-randr(t::Trace, vn::VarName, distr::Distribution) = randr(t.vi, vn, distr, 0, false, nothing, true)
+randr(t::Trace, vn::VarName, distr::Distribution) = randr(t.vi, vn, distr, 0, nothing, true)
 
 # generate a new random variable, no replay
 randc(t::Trace, vn::VarName, distr :: Distribution) = randoc(t.vi, vn, distr)

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -25,11 +25,12 @@ _m = realpart(vi[mvn][1])
 ∇E = gradient(vi, ad_test_f)
 grad_Turing = sort([∇E[v][1] for v in keys(vi)])
 
+dist_s = InverseGamma(2,3)
+
 # Hand-written logjoint
 function logjoint(x::Vector)
   s = x[2]
-  dist_s = InverseGamma(2,3)
-  s = invlink(dist_s, s)        # as we now work in R, we need to do R -> X for s
+  s = invlink(dist_s, s)
   m = x[1]
   lik_dist = Normal(m, sqrt(s))
   lp = logpdf(dist_s, s, true) + logpdf(Normal(0,sqrt(s)), m, true)
@@ -39,6 +40,7 @@ end
 
 # Call ForwardDiff's AD
 g = x -> ForwardDiff.gradient(logjoint, x);
+_s = link(dist_s, _s)
 _x = [_m, _s]
 grad_FWAD = sort(-g(_x))
 

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -30,17 +30,17 @@ dist_s = InverseGamma(2,3)
 # Hand-written logjoint
 function logjoint(x::Vector)
   s = x[2]
-  s = invlink(dist_s, s)
+  # s = invlink(dist_s, s)
   m = x[1]
   lik_dist = Normal(m, sqrt(s))
-  lp = logpdf(dist_s, s, true) + logpdf(Normal(0,sqrt(s)), m, true)
+  lp = logpdf(dist_s, s, false) + logpdf(Normal(0,sqrt(s)), m, false)
   lp += logpdf(lik_dist, 1.5) + logpdf(lik_dist, 2.0)
   lp
 end
 
 # Call ForwardDiff's AD
 g = x -> ForwardDiff.gradient(logjoint, x);
-_s = link(dist_s, _s)
+# _s = link(dist_s, _s)
 _x = [_m, _s]
 grad_FWAD = sort(-g(_x))
 

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -68,8 +68,8 @@ dist= Normal(0, 1)
 
 vi = VarInfo()
 
-r = rand(vi, vn_w, dist, pg, false)
-r = rand(vi, vn_u, dist, pg, false)
+r = rand(vi, vn_w, dist, pg)
+r = rand(vi, vn_u, dist, pg)
 r = rand(vi, vn_x, dist, pg)
 r = rand(vi, vn_y, dist, pg)
 r = rand(vi, vn_z, dist, pg)
@@ -82,8 +82,8 @@ r = rand(vi, vn_z, dist, pg)
 
 r = rand(vi, vn_w, dist, hmc)
 r = rand(vi, vn_u, dist, hmc)
-r = rand(vi, vn_x, dist, hmc, false)
-r = rand(vi, vn_y, dist, hmc, false)
-r = rand(vi, vn_z, dist, hmc, false)
+r = rand(vi, vn_x, dist, hmc)
+r = rand(vi, vn_y, dist, hmc)
+r = rand(vi, vn_z, dist, hmc)
 
 @test vi.gids == [2,2,1,1,1]

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -19,7 +19,7 @@ vi = VarInfo()
 dists = [Normal(0, 1), MvNormal([0; 0], [1.0 0; 0 1.0]), Wishart(7, [1 0.5; 0.5 1])]
 
 vn_w = VarName(gensym(), :w, "", 1)
-randr(vi, vn_w, dists[1], 2, false, nothing, true)
+randr(vi, vn_w, dists[1], 2, nothing, true)
 
 vn_x = VarName(gensym(), :x, "", 1)
 vn_y = VarName(gensym(), :y, "", 1)
@@ -27,11 +27,9 @@ vn_z = VarName(gensym(), :z, "", 1)
 vns = [vn_x, vn_y, vn_z]
 
 for i = 1:3
-  r = randr(vi, vns[i], dists[i], 1, true, nothing, false)
+  r = randr(vi, vns[i], dists[i], 1, nothing, false)
   val = vi[vns[i]]
-  val = reconstruct(dists[i], val)
-  val = invlink(dists[i], val)
-  @test sum(realpart(val) - r) <= 1e-9
+  @test sum(val - r) <= 1e-9
 end
 
 # println(vi)
@@ -40,7 +38,7 @@ end
 @test length(groupvals(vi, 2)) == 1
 
 vn_u = VarName(gensym(), :u, "", 1)
-randr(vi, vn_u, dists[1], 2, false, nothing, true)
+randr(vi, vn_u, dists[1], 2, nothing, true)
 
 # println(vi)
 

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -28,7 +28,7 @@ vns = [vn_x, vn_y, vn_z]
 
 for i = 1:3
   r = randr(vi, vns[i], dists[i], 1, nothing, false)
-  val = vi[vns[i]]
+  val = reconstruct(dists[i], vi[vns[i]])
   @test sum(val - r) <= 1e-9
 end
 
@@ -62,7 +62,7 @@ end
 g = GibbsSampler{Gibbs}(gdemo(), Gibbs(1000, PG(10, 2, :x, :y, :z), HMC(1, 0.4, 8, :w, :u)))
 
 pg = g.samplers[1]
-println(pg)
+# println(pg)
 hmc = g.samplers[2]
 dist= Normal(0, 1)
 


### PR DESCRIPTION
Resolves https://github.com/yebai/Turing.jl/issues/142

By default HMC also stores untransformed variables in VarInfo but it will do X -> R and R -> X before and after each HMC step (but not each `leapfrog()` and `gradient()`)

Also I finally keep the `trans` field in `VarInfo` because within the HMC step we need to know which variables are temporarily in R, so that we can call `logpdf()` with the right parameter. This actually gives a very neat code in a higher level, e.g. the `assume()` of HMC is very clean now.