### PR TITLE
Add a method to set chunk size

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -20,7 +20,7 @@ import Base: ~, convert, promote_rule
 #################
 
 # Turing essentials - modelling macros and inference algorithms
-export @model, @~, InferenceAlgorithm, HMC, IS, SMC, PG, Gibbs, sample, Chain, Sample, Sampler, ImportanceSampler, HMCSampler
+export @model, @~, InferenceAlgorithm, HMC, IS, SMC, PG, Gibbs, sample, Chain, Sample, Sampler, ImportanceSampler, HMCSampler, setchunksize
 export VarName, VarInfo, nextvn, randr, randoc, retain, groupvals
 export Dual
 
@@ -37,7 +37,7 @@ export dprintln
 const TURING = Dict{Symbol, Any}()
 global sampler = nothing
 global debug_level = 0
-global CHUNKSIZE = 1000
+global CHUNKSIZE = 50
 
 ##########
 # Helper #

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -96,9 +96,12 @@ function step(model, spl::Sampler{HMC}, varInfo::VarInfo, is_first::Bool)
   end
 end
 
+setchunksize(chun_size::Int) = global CHUNKSIZE = chunk_size
+sample(model::Function, alg::HMC) = sample(model, alg, CHUNKSIZE)
+
 # NOTE: in the previous code, `sample` would call `run`; this is
 # now simplified: `sample` and `run` are merged into one function.
-function sample(model::Function, alg::HMC, chunk_size::Int = 5)
+function sample(model::Function, alg::HMC, chunk_size::Int)
   global CHUNKSIZE = chunk_size;
   global sampler = HMCSampler{HMC}(alg);
 


### PR DESCRIPTION
I added a function `setchunksize()` to update the global variable for chunk size. My motivation is that our old way to old put that in `sample()` level cannot set the chunk size when HMC is used in Gibbs.