### PR TITLE
Fix hmc bug

### DIFF
--- a/benchmarks/simple-normal-mixture.run.jl
+++ b/benchmarks/simple-normal-mixture.run.jl
@@ -2,7 +2,7 @@ include("simple-normal-mixture.data.jl")
 include("simple-normal-mixture.model.jl")
 
 # NOTE: I only run a sub-set of the data as running the whole is quite slow
-bench_res = tbenchmark("Gibbs(2000, PG(50, 1, :k), HMC(1, 0.1, 5, :theta, :mu))", "nmmodel", "y[1:100]")
+bench_res = tbenchmark("Gibbs(2000, PG(50, 1, :k), HMC(1, 0.02, 4, :theta), HMC(1, 0.2, 3, :mu))", "nmmodel", "y[1:100]")
 logd = build_logd("Simple Gaussian Mixture Model", bench_res...)
 
 include("simple-normal-mixture-stan.run.jl")

--- a/benchmarks/simple-normal-mixture.run.jl
+++ b/benchmarks/simple-normal-mixture.run.jl
@@ -2,7 +2,7 @@ include("simple-normal-mixture.data.jl")
 include("simple-normal-mixture.model.jl")
 
 # NOTE: I only run a sub-set of the data as running the whole is quite slow
-bench_res = tbenchmark("Gibbs(2000, PG(50, 1, :k), HMC(1, 0.02, 4, :theta), HMC(1, 0.2, 3, :mu))", "nmmodel", "y[1:100]")
+bench_res = tbenchmark("Gibbs(1000, HMC(1, 0.05, 1, :theta), PG(50, 1, :k), HMC(1, 0.2, 3, :mu))", "nmmodel", "y[1:100]")
 logd = build_logd("Simple Gaussian Mixture Model", bench_res...)
 
 include("simple-normal-mixture-stan.run.jl")

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -93,6 +93,8 @@ function step(model, spl::Sampler{HMC}, varInfo::VarInfo, is_first::Bool)
     dprintln(2, "computing ΔH...")
     ΔH = H - oldH
 
+    realpart!(varInfo)
+
     dprintln(2, "decide wether to accept...")
     if ΔH < 0 || rand() < exp(-ΔH)      # accepted
       true, varInfo

--- a/src/samplers/support/helper.jl
+++ b/src/samplers/support/helper.jl
@@ -4,7 +4,7 @@
 
 realpart(f)        = f
 realpart(d::Dual)  = d.value
-realpart(d::Array) = map(x -> x.value, d)
+realpart(d::Array) = map(x -> realpart(x), d)
 dualpart(d::Dual)  = d.partials.values
 dualpart(d::Array) = map(x -> x.partials.values, d)
 
@@ -61,6 +61,13 @@ Sample(vi::VarInfo) = begin
   # NOTE: do we need to check if lp is 0?
   value[:lp] = realpart(vi.logjoint)
   Sample(weight, value)
+end
+
+function realpart!(vi::VarInfo)
+  for uid in keys(vi)
+    vi[uid] = realpart(vi[uid])
+  end
+  vi.logjoint = realpart(vi.logjoint)
 end
 
 # X -> R for all variables associated with given sampler


### PR DESCRIPTION
This PR resolves #160.

The problem was between two HMC samplers, say one responsible for `a` and another for `b`, they `Daul` type value is not reset to `Real`. If `a` and `b` have different dimensions, when we do arithmatic operation on them, `ForwardDiff` will give error.

I added one more step inside HMC step to reset all `Dual` to `Real` to address this issue. The benchmark for Simple Normal Mixture now uses two HMC steps (for variables with different dimensions) as an example.