### PR TITLE
Add a thin flag for Gibbs and bugfix

### DIFF
--- a/test/gibbs_constructor.jl
+++ b/test/gibbs_constructor.jl
@@ -13,11 +13,13 @@ end
 s1 = Gibbs(1000, HMC(10, 0.1, 5, :s, :m))
 s2 = Gibbs(1000, PG(10, 10, :s, :m))
 s3 = Gibbs(1000, PG(10, 2, :s), HMC(1, 0.4, 8, :m))
+s4 = Gibbs(1000, PG(10, 3, :s), HMC(2, 0.4, 8, :m); thin=false)
 
 
 c1 = sample(gdemo(), s1)
 c2 = sample(gdemo(), s2)
 c3 = sample(gdemo(), s3)
+c4 = sample(gdemo(), s4)
 
 # Very loose bound, only for testing constructor.
 @test_approx_eq_eps mean(c1[:s]) 49/24 1
@@ -26,6 +28,10 @@ c3 = sample(gdemo(), s3)
 @test_approx_eq_eps mean(c2[:m]) 7/6 1
 @test_approx_eq_eps mean(c3[:s]) 49/24 1
 @test_approx_eq_eps mean(c3[:m]) 7/6 1
+
+@test length(c4[:s]) == 1000 * (3 + 2)
+@test_approx_eq_eps mean(c4[:s]) 49/24 1
+@test_approx_eq_eps mean(c4[:m]) 7/6 1
 
 
 # Test group_id of each samplers


### PR DESCRIPTION
Targeting https://github.com/yebai/Turing.jl/issues/159

Add a optional parameter to Gibbs sampler to control whether to thin the output samples or not.

```julia
s = Gibbs(1000, PG(10, 3, :s), HMC(2, 0.4, 8, :m); thin=false)
# => will output 1000 * (3 + 2) samples then
```

Also found a silly bug in the main loop of Gibbs which makes us actually only run each component for 1 iteration before.
