### PR TITLE
Improve leapfrog

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5.0-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
     MINGW_DIR: mingw64
     # MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/5.3.0/threads-win32/seh/x86_64-5.3.0-release-win32-seh-rt_v4-rev0.7z/download
     MINGW_URL: http://mlg.eng.cam.ac.uk/hong/x86_64-5.3.0-release-win32-seh-rt_v4-rev0.7z
     MINGW_ARCHIVE: x86_64-5.3.0-release-win32-seh-rt_v4-rev0.7z
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5.0-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
     MINGW_DIR: mingw32
     # MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/5.3.0/threads-win32/dwarf/i686-5.3.0-release-win32-dwarf-rt_v4-rev0.7z/download
     MINGW_URL: http://mlg.eng.cam.ac.uk/hong/i686-5.3.0-release-win32-dwarf-rt_v4-rev0.7z
@@ -20,7 +20,7 @@ notifications:
 cache:
 # Cache large downloads to avoid network unreliability
   - "%MINGW_ARCHIVE%"
-# - C:\Users\appveyor\.julia\v0.5
+  - C:\Users\appveyor\.julia\v0.5
   
 install:
 # Download and install MinGW
@@ -40,9 +40,10 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.update(); Pkg.pin(\"Gadfly\", v"0.6.0");
+      Pkg.update();
       rm(Pkg.dir(\"Turing\"), force=true, recursive=true);
       Pkg.clone(pwd(), \"Turing\"); 
+      Pkg.pin(\"Gadfly\", v\"0.6.0\");
       Pkg.build(\"Turing\")"
 
 test_script:

--- a/benchmarks/benchmarkhelper.jl
+++ b/benchmarks/benchmarkhelper.jl
@@ -8,7 +8,7 @@ end
 # Run benchmark
 tbenchmark(alg::String, model::String, data::String) = begin
   chain, time, mem, _, _  = eval(parse("@timed sample($model($data), $alg)"))
-  alg, time, mem, chain, chain
+  alg, time, mem, chain, deepcopy(chain)
 end
 
 # Build logd from Turing chain

--- a/benchmarks/benchmarkhelper.jl
+++ b/benchmarks/benchmarkhelper.jl
@@ -8,7 +8,7 @@ end
 # Run benchmark
 tbenchmark(alg::String, model::String, data::String) = begin
   chain, time, mem, _, _  = eval(parse("@timed sample($model($data), $alg)"))
-  alg, time, mem, chain
+  alg, time, mem, chain, chain
 end
 
 # Build logd from Turing chain

--- a/benchmarks/benchmarkhelper.jl
+++ b/benchmarks/benchmarkhelper.jl
@@ -12,7 +12,7 @@ tbenchmark(alg::String, model::String, data::String) = begin
 end
 
 # Build logd from Turing chain
-build_logd(name::String, engine::String, time, mem, tchain) = begin
+build_logd(name::String, engine::String, time, mem, tchain, _) = begin
   Dict(
     "name" => name,
     "engine" => engine,

--- a/benchmarks/lda-stan.run.jl
+++ b/benchmarks/lda-stan.run.jl
@@ -1,15 +1,18 @@
+using Distributions, Turing, Stan, Mamba
+
+include("benchmarkhelper.jl")
 include("lda-stan.data.jl")
 include("lda-stan.model.jl")
 
 stan_model_name = "LDA"
-ldastan = Stanmodel(name=stan_model_name, model=ldastanmodel, nchains=1);
+ldastan = Stanmodel(Sample(save_warmup=true), name=stan_model_name, model=ldastanmodel, nchains=1);
 
 lda_stan_sim = stan(ldastan, ldastandata, CmdStanDir=CMDSTAN_HOME, summary=false);
 # lda_stan_sim.names
 
 lda_stan_d_raw = Dict()
 for i = 1:2, j = 1:5
-  lda_stan_d_raw["phi[$i][$j]"] = lda_stan_sim[1:1000, ["phi.$i.$j"], :].value[:]
+  lda_stan_d_raw["phi[$i][$j]"] = lda_stan_sim[1001:2000, ["phi.$i.$j"], :].value[:]
 end
 
 lda_stan_d = Dict()

--- a/benchmarks/naive.bayes-stan.run.jl
+++ b/benchmarks/naive.bayes-stan.run.jl
@@ -1,15 +1,18 @@
+using Distributions, Turing, Stan, Mamba
+
+include("benchmarkhelper.jl")
 include("naive.bayes-stan.data.jl")
 include("naive.bayes-stan.model.jl")
 
 stan_model_name = "Naive_Bayes"
-nbstan = Stanmodel(name=stan_model_name, model=naivebayesstanmodel, nchains=1);
+nbstan = Stanmodel(Sample(save_warmup=true), name=stan_model_name, model=naivebayesstanmodel, nchains=1);
 
 nb_stan_sim = stan(nbstan, nbstandata, CmdStanDir=CMDSTAN_HOME, summary=false);
 # nb_stan_sim.names
 
 stan_d_raw = Dict()
 for i = 1:4, j = 1:10
-  stan_d_raw["phi[$i][$j]"] = nb_stan_sim[1:1000, ["phi.$i.$j"], :].value[:]
+  stan_d_raw["phi[$i][$j]"] = nb_stan_sim[1001:2000, ["phi.$i.$j"], :].value[:]
 end
 
 stan_d = Dict()

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -23,6 +23,7 @@ global const CACHERANGES = 0b01
 using StatsFuns
 using Distributions
 using ForwardDiff: Dual, npartials    # for automatic differentiation
+using UnicodePlots
 
 abstract InferenceAlgorithm{P}
 type Sampler{T<:InferenceAlgorithm}

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -39,7 +39,7 @@ type VarInfo
   dists       ::    Vector{Distribution}
   gids        ::    Vector{Int}   # group ids
   trans       ::    Vector{Bool}
-  logp        ::    Real
+  logp        ::    Real          # NOTE: logp should be a vector.
   logw        ::    Real          # NOTE: importance weight when sampling from the prior.
   index       ::    Int           # index of current randomness
   num_produce ::    Int           # num of produce calls from trace, each produce corresponds to an observe.

--- a/src/samplers/gibbs.jl
+++ b/src/samplers/gibbs.jl
@@ -72,10 +72,12 @@ function sample(model::Function, alg::Gibbs)
   i_thin = 1
 
   # Gibbs steps
-  @showprogress 1 "[Gibbs] Sampling..." for i = 1:n
+  spl.info[:progress] = ProgressMeter.Progress(n, 1, "[Gibbs] Sampling...", 0)
+  for i = 1:n
     dprintln(2, "Gibbs stepping...")
 
     for local_spl in spl.info[:samplers]
+      local_spl.info[:progress] = spl.info[:progress]
       # dprintln(2, "Sampler stepping...")
       dprintln(2, "$(typeof(local_spl)) stepping...")
       # println(varInfo)
@@ -122,6 +124,7 @@ function sample(model::Function, alg::Gibbs)
     if spl.alg.thin
       samples[i].value = Sample(varInfo).value
     end
+    ProgressMeter.next!(spl.info[:progress])
 
   end
 

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -69,7 +69,8 @@ function step(model, spl::Sampler{HMC}, vi::VarInfo, is_first::Bool)
     dprintln(2, "computing ΔH...")
     ΔH = H - oldH
 
-    ProgressMeter.update!(spl.info[:progress], spl.info[:progress].counter;
+    haskey(spl.info, :progress) && ProgressMeter.update!(spl.info[:progress],
+                                spl.info[:progress].counter;
                                 showvalues = [(:ϵ, ϵ), (:α, min(1,exp(-ΔH)))])
 
     dprintln(3, "R -> X...")

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -69,6 +69,9 @@ function step(model, spl::Sampler{HMC}, vi::VarInfo, is_first::Bool)
     dprintln(2, "computing ΔH...")
     ΔH = H - oldH
 
+    ProgressMeter.update!(spl.info[:progress], spl.info[:progress].counter;
+                                showvalues = [(:ϵ, ϵ), (:α, min(1,exp(-ΔH)))])
+
     dprintln(3, "R -> X...")
     if spl.alg.gid != 0 vi = invlink(vi, spl); cleandual!(vi) end
 
@@ -105,7 +108,8 @@ function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
   if spl.alg.gid == 0 vi = link(vi, spl) end
 
   # HMC steps
-  @showprogress 1 "[$alg_str] Sampling..." for i = 1:n
+  spl.info[:progress] = ProgressMeter.Progress(n, 1, "[$alg_str] Sampling...", 0)
+  for i = 1:n
     dprintln(2, "recording old θ...")
     old_vi = deepcopy(vi)
     dprintln(2, "$alg_str stepping...")
@@ -117,6 +121,7 @@ function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
       vi = old_vi
       samples[i] = samples[i - 1]
     end
+    ProgressMeter.next!(spl.info[:progress])
   end
 
   accept_rate = accept_num / n    # calculate the accept rate

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -61,10 +61,7 @@ function step(model, spl::Sampler{HMC}, vi::VarInfo, is_first::Bool)
     oldH = find_H(p, model, vi, spl)
 
     dprintln(2, "leapfrog stepping...")
-    vi, p, reject = leapfrog(vi, p, τ, ϵ, model, spl)
-
-    # Directly reject this HMC step if leapfrog meets error
-    if reject return false, vi end
+    vi, p, _ = leapfrog(vi, p, τ, ϵ, model, spl)
 
     dprintln(2, "computing new H...")
     H = find_H(p, model, vi, spl)

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -86,7 +86,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
       spl.info[:ϵ_bar], spl.info[:H_bar] = ϵ_bar, H_bar
     elseif m == spl.alg.n_adapt
       dprintln(0, " Adapted ϵ = $ϵ, $m HMC iterations is used for adaption.")
-      show(scatterplot(1:length(spl.info[:ϵ]), spl.info[:ϵ]/spl.info[:ϵ][1]))
+      show(scatterplot(1:length(spl.info[:ϵ]), spl.info[:ϵ]/spl.info[:ϵ][end]))
       push!(spl.info[:ϵ], spl.info[:ϵ_bar])
     end
 

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -67,17 +67,17 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     vi, p, τ_valid = leapfrog(vi, p, τ, ϵ, model, spl)
 
     dprintln(2, "computing new H...")
-    H = τ_valid == 0 ? oldH : find_H(p, model, vi, spl)
+    H = τ_valid == 0 ? Inf : find_H(p, model, vi, spl)
 
     dprintln(2, "computing ΔH...")
     ΔH = H - oldH
 
-    α = τ_valid == 0 ? 0 : min(1, exp(-ΔH))  # MH accept rate
+    α = min(1, exp(-ΔH))  # MH accept rate
 
     # Use Dual Averaging to adapt ϵ
     m = spl.info[:m] += 1
     if m < spl.alg.n_adapt
-      dprintln(0, " ϵ = $ϵ, α = $α, exp(-ΔH)=$(exp(-ΔH))")
+      dprintln(1, " ϵ = $ϵ, α = $α, exp(-ΔH)=$(exp(-ΔH))")
       H_bar = (1 - 1 / (m + t_0)) * H_bar + 1 / (m + t_0) * (δ - α)
       ϵ = exp(μ - sqrt(m) / γ * H_bar)
       ϵ_bar = exp(m^(-κ) * log(ϵ) + (1 - m^(-κ)) * log(ϵ_bar))

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -73,8 +73,9 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
 
     α = min(1, exp(-ΔH))  # MH accept rate
 
-    ProgressMeter.update!(spl.info[:progress], spl.info[:progress].counter;
-                                            showvalues = [(:ϵ, ϵ), (:α, α)])
+    haskey(spl.info, :progress) && ProgressMeter.update!(spl.info[:progress],
+                                spl.info[:progress].counter;
+                                showvalues = [(:ϵ, ϵ), (:α, α)])
 
     # Use Dual Averaging to adapt ϵ
     m = spl.info[:m] += 1

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -30,15 +30,16 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     if spl.alg.gid != 0 vi = link(vi, spl) end
 
     # Heuristically find optimal ϵ
-    ϵ_bar, ϵ = find_good_eps(model, spl, vi)
+    # ϵ_bar, ϵ = find_good_eps(model, spl, vi)
+    ϵ = find_good_eps(model, spl, vi)
 
     dprintln(3, "R -> X...")
     if spl.alg.gid != 0 vi = invlink(vi, spl) end
 
     spl.info[:ϵ] = [ϵ]
     spl.info[:μ] = log(10 * ϵ)
-    # spl.info[:ϵ_bar] = 1.0
-    spl.info[:ϵ_bar] = ϵ_bar  # NOTE: is this correct?
+    spl.info[:ϵ_bar] = 1.0
+    # spl.info[:ϵ_bar] = ϵ_bar  # NOTE: is this correct?
     spl.info[:H_bar] = 0.0
     spl.info[:m] = 0
 

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -77,7 +77,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     # Use Dual Averaging to adapt ϵ
     m = spl.info[:m] += 1
     if m < spl.alg.n_adapt
-      # dprintln(1, " ϵ = $ϵ, α = $α, exp(-ΔH)=$(exp(-ΔH))")
+      dprintln(0, " ϵ = $ϵ, α = $α, exp(-ΔH)=$(exp(-ΔH))")
       H_bar = (1 - 1 / (m + t_0)) * H_bar + 1 / (m + t_0) * (δ - α)
       ϵ = exp(μ - sqrt(m) / γ * H_bar)
       ϵ_bar = exp(m^(-κ) * log(ϵ) + (1 - m^(-κ)) * log(ϵ_bar))
@@ -85,7 +85,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
       spl.info[:ϵ_bar], spl.info[:H_bar] = ϵ_bar, H_bar
     elseif m == spl.alg.n_adapt
       dprintln(0, " Adapted ϵ = $ϵ, $m HMC iterations is used for adaption.")
-      show(scatterplot(1:length(spl.info[:ϵ]), spl.info[:ϵ]))
+      show(scatterplot(1:length(spl.info[:ϵ]), spl.info[:ϵ]/spl.info[:ϵ][1]))
       push!(spl.info[:ϵ], spl.info[:ϵ_bar])
     end
 

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -1,5 +1,3 @@
-using UnicodePlots
-
 immutable HMCDA <: InferenceAlgorithm
   n_samples ::  Int       # number of samples
   n_adapt   ::  Int       # number of samples with adaption for epsilon
@@ -74,6 +72,9 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     ΔH = H - oldH
 
     α = min(1, exp(-ΔH))  # MH accept rate
+
+    ProgressMeter.update!(spl.info[:progress], spl.info[:progress].counter;
+                                            showvalues = [(:ϵ, ϵ), (:α, α)])
 
     # Use Dual Averaging to adapt ϵ
     m = spl.info[:m] += 1

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -88,7 +88,6 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
       spl.info[:ϵ_bar], spl.info[:H_bar] = ϵ_bar, H_bar
     elseif m == spl.alg.n_adapt
       dprintln(0, " Adapted ϵ = $ϵ, $m HMC iterations is used for adaption.")
-      show(scatterplot(1:length(spl.info[:ϵ]), spl.info[:ϵ]/spl.info[:ϵ][end]))
       push!(spl.info[:ϵ], spl.info[:ϵ_bar])
     end
 

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -1,3 +1,5 @@
+using UnicodePlots
+
 immutable HMCDA <: InferenceAlgorithm
   n_samples ::  Int       # number of samples
   n_adapt   ::  Int       # number of samples with adaption for epsilon
@@ -33,7 +35,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     dprintln(3, "R -> X...")
     if spl.alg.gid != 0 vi = invlink(vi, spl) end
 
-    spl.info[:ϵ] = ϵ
+    spl.info[:ϵ] = [ϵ]
     spl.info[:μ] = log(10 * ϵ)
     # spl.info[:ϵ_bar] = 1.0
     spl.info[:ϵ_bar] = ϵ_bar  # NOTE: is this correct?
@@ -45,7 +47,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     # Set parameters
     δ = spl.alg.delta
     λ = spl.alg.lambda
-    ϵ = spl.info[:ϵ]
+    ϵ = spl.info[:ϵ][end]
 
     dprintln(2, "current ϵ: $ϵ")
     μ, γ, t_0, κ = spl.info[:μ], 0.05, 10, 0.75
@@ -62,20 +64,15 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
 
     τ = max(1, round(λ / ϵ))
     dprintln(2, "leapfrog for $τ steps with step size $ϵ")
-    vi, p, reject = leapfrog(vi, p, τ, ϵ, model, spl)
+    vi, p, τ_valid = leapfrog(vi, p, τ, ϵ, model, spl)
 
-    if reject
-      α = 0
-    else
-      dprintln(2, "computing new H...")
-      H = find_H(p, model, vi, spl)
+    dprintln(2, "computing new H...")
+    H = τ_valid == 0 ? oldH : find_H(p, model, vi, spl)
 
-      dprintln(2, "computing ΔH...")
-      ΔH = H - oldH
-      isnan(ΔH) && warn(" ΔH = NaN, H=$H, oldH=$oldH.")
+    dprintln(2, "computing ΔH...")
+    ΔH = H - oldH
 
-      α = min(1, exp(-ΔH))  # MH accept rate
-    end
+    α = τ_valid == 0 ? 0 : min(1, exp(-ΔH))  # MH accept rate
 
     # Use Dual Averaging to adapt ϵ
     m = spl.info[:m] += 1
@@ -84,14 +81,13 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
       H_bar = (1 - 1 / (m + t_0)) * H_bar + 1 / (m + t_0) * (δ - α)
       ϵ = exp(μ - sqrt(m) / γ * H_bar)
       ϵ_bar = exp(m^(-κ) * log(ϵ) + (1 - m^(-κ)) * log(ϵ_bar))
-      spl.info[:ϵ] = ϵ
+      push!(spl.info[:ϵ], ϵ)
       spl.info[:ϵ_bar], spl.info[:H_bar] = ϵ_bar, H_bar
     elseif m == spl.alg.n_adapt
-      spl.info[:ϵ] = spl.info[:ϵ_bar]
       dprintln(0, " Adapted ϵ = $ϵ, $m HMC iterations is used for adaption.")
+      show(scatterplot(1:length(spl.info[:ϵ]), spl.info[:ϵ]))
+      push!(spl.info[:ϵ], spl.info[:ϵ_bar])
     end
-
-    if reject return false, vi end
 
     dprintln(3, "R -> X...")
     if spl.alg.gid != 0 vi = invlink(vi, spl); cleandual!(vi) end

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -59,7 +59,7 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
     θm, θp, rm, rp, j, vi_new, n, s = deepcopy(vi), deepcopy(vi), deepcopy(p), deepcopy(p), 0, deepcopy(vi), 1, 1
 
     local α, n_α
-    while s == 1 && j <= 4
+    while s == 1 && j <= 2
       v_j = rand([-1, 1]) # Note: this variable actually does not depend on j;
                           #       it is set as `v_j` just to be consistent to the paper
       if v_j == -1

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -75,7 +75,7 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
       end
       n = n + n′
 
-      s = s′ * (direction(θm, θp, rm, spl) >= 0 ? 1 : 0) * (direction(θm, θp, rp, spl) >= 0 ? 1 : 0)
+      s = s′ * (dot(θp[spl] - θm[spl], rm) >= 0 ? 1 : 0) * (dot(θp[spl] - θm[spl], rp) >= 0 ? 1 : 0)
       j = j + 1
     end
 
@@ -134,7 +134,7 @@ function build_tree(θ, r, logu, v, j, ϵ, H0, model, spl)
         end
         α′ = α′ + α′′
         n′_α = n′_α + n′′_α
-        s′ = s′′ * (direction(θm, θp, rm, spl) >= 0 ? 1 : 0) * (direction(θm, θp, rp, spl) >= 0 ? 1 : 0)
+        s′ = s′′ * (dot(θp[spl] - θm[spl], rm) >= 0 ? 1 : 0) * (dot(θp[spl] - θm[spl], rp) >= 0 ? 1 : 0)
         n′ = n′ + n′′
       end
       return θm, rm, θp, rp, θ′, n′, s′, α′, n′_α, reject

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -112,10 +112,10 @@ function build_tree(θ, r, logu, v, j, ϵ, H0, model, spl)
     if j == 0
       # Base case - take one leapfrog step in the direction v.
       θ′, r′, reject = leapfrog(θ, r, 1, v * ϵ, model, spl)
-      H = -find_H(r′, model, θ′, spl)
-      n′ = reject ? 0 : (logu <= H) ? 1 : 0
-      s′ = reject ? 0 : (logu < Δ_max + H) ? 1 : 0
-      α′ = reject ? 0 : exp(min(0, H - (-H0)))
+      H′ = reject ? H0 : find_H(r′, model, θ′, spl)
+      n′ = reject ? 0 : (logu <= -H′) ? 1 : 0
+      s′ = reject ? 0 : (logu < Δ_max + -H′) ? 1 : 0
+      α′ = reject ? 0 : exp(min(0, -H′ - (-H0)))
       return θ′, r′, deepcopy(θ′), deepcopy(r′), deepcopy(θ′), n′, s′, α′, 1, reject
     else
       # Recursion - build the left and right subtrees.

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -68,8 +68,9 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
         _, _, θp, rp, θ′, n′, s′, α, n_α = build_tree(θp, rp, logu, v_j, j, ϵ, H0, model, spl)
       end
 
-      ProgressMeter.update!(spl.info[:progress], spl.info[:progress].counter;
-                                       showvalues = [(:ϵ, ϵ), (:tree_depth, j)])
+      haskey(spl.info, :progress) && ProgressMeter.update!(spl.info[:progress],
+                                  spl.info[:progress].counter;
+                                  showvalues = [(:ϵ, ϵ), (:tree_depth, j)])
 
       if s′ == 1 && rand() < min(1, n′ / n)
         vi_new = deepcopy(θ′)

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -22,15 +22,16 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
     if spl.alg.gid != 0 vi = link(vi, spl) end
 
     # Heuristically find optimal ϵ
-    ϵ_bar, ϵ = find_good_eps(model, spl, vi)
+    # ϵ_bar, ϵ = find_good_eps(model, spl, vi)
+    ϵ = find_good_eps(model, spl, vi)
 
     dprintln(3, "R -> X...")
     if spl.alg.gid != 0 vi = invlink(vi, spl) end
 
     spl.info[:ϵ] = ϵ
     spl.info[:μ] = log(10 * ϵ)
-    # spl.info[:ϵ_bar] = 1.0
-    spl.info[:ϵ_bar] = ϵ_bar  # NOTE: is this correct?
+    spl.info[:ϵ_bar] = 1.0
+    # spl.info[:ϵ_bar] = ϵ_bar  # NOTE: is this correct?
     spl.info[:H_bar] = 0.0
     spl.info[:m] = 0
 
@@ -39,10 +40,8 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
     # Set parameters
     δ = spl.alg.delta
     ϵ = spl.info[:ϵ]
-    # ϵ = 0.2
-    println("ϵ: $ϵ")
 
-    dprintln(2, "current ϵ: $ϵ")
+    dprintln(0, "current ϵ: $ϵ")
     μ, γ, t_0, κ = spl.info[:μ], 0.05, 10, 0.75
     ϵ_bar, H_bar = spl.info[:ϵ_bar], spl.info[:H_bar]
 
@@ -112,9 +111,9 @@ function build_tree(θ, r, logu, v, j, ϵ, H0, model, spl)
       # Base case - take one leapfrog step in the direction v.
       θ′, r′, τ_valid = leapfrog(θ, r, 1, v * ϵ, model, spl)
       # Use old H to save computation
-      H′ = τ_valid == 0 ? H0 : find_H(r′, model, θ′, spl)
+      H′ = τ_valid == 0 ? Inf : find_H(r′, model, θ′, spl)
       n′ = (logu <= -H′) ? 1 : 0
-      s′ = τ_valid == 0 ? 0 : (logu < Δ_max + -H′) ? 1 : 0
+      s′ = (logu < Δ_max + -H′) ? 1 : 0
       α′ = exp(min(0, -H′ - (-H0)))
       return θ′, r′, deepcopy(θ′), deepcopy(r′), deepcopy(θ′), n′, s′, α′, 1
     else

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -41,7 +41,6 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
     δ = spl.alg.delta
     ϵ = spl.info[:ϵ]
 
-    dprintln(0, "current ϵ: $ϵ")
     μ, γ, t_0, κ = spl.info[:μ], 0.05, 10, 0.75
     ϵ_bar, H_bar = spl.info[:ϵ_bar], spl.info[:H_bar]
 
@@ -60,7 +59,7 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
     θm, θp, rm, rp, j, vi_new, n, s = deepcopy(vi), deepcopy(vi), deepcopy(p), deepcopy(p), 0, deepcopy(vi), 1, 1
 
     local α, n_α
-    while s == 1
+    while s == 1 && j <= 4
       v_j = rand([-1, 1]) # Note: this variable actually does not depend on j;
                           #       it is set as `v_j` just to be consistent to the paper
       if v_j == -1
@@ -68,6 +67,8 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
       else
         _, _, θp, rp, θ′, n′, s′, α, n_α = build_tree(θp, rp, logu, v_j, j, ϵ, H0, model, spl)
       end
+
+      dprintln(1, "ϵ = $ϵ, s′ = $s′， j = $j.")
 
       if s′ == 1 && rand() < min(1, n′ / n)
         vi_new = deepcopy(θ′)

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -68,7 +68,8 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
         _, _, θp, rp, θ′, n′, s′, α, n_α = build_tree(θp, rp, logu, v_j, j, ϵ, H0, model, spl)
       end
 
-      dprintln(1, "ϵ = $ϵ, s′ = $s′， j = $j.")
+      ProgressMeter.update!(spl.info[:progress], spl.info[:progress].counter;
+                                       showvalues = [(:ϵ, ϵ), (:tree_depth, j)])
 
       if s′ == 1 && rand() < min(1, n′ / n)
         vi_new = deepcopy(θ′)
@@ -90,7 +91,8 @@ function step(model, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
       ϵ_bar = exp(m^(-κ) * log(ϵ) + (1 - m^(-κ)) * log(ϵ_bar))
       spl.info[:ϵ] = ϵ
       spl.info[:ϵ_bar], spl.info[:H_bar] = ϵ_bar, H_bar
-    else
+    elseif m == spl.alg.n_adapt
+      dprintln(0, " Adapted ϵ = $ϵ, $m HMC iterations is used for adaption.")
       spl.info[:ϵ] = spl.info[:ϵ_bar]
     end
 

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -39,17 +39,8 @@ function leapfrog(_vi, _p, τ, ϵ, model, spl)
 
     grad = gradient2(vi, model, spl)
 
-    if realpart(vi.logp) == -Inf
-      dwarn(0, "Log-joint is -Inf")
-      break
-    elseif isnan(realpart(vi.logp)) || realpart(vi.logp) == Inf
-      dwarn(0, "Numerical error: vi.lojoint = $(vi.logp)")
-      pop!(vi.vals); p = p_old; break
-    end
-
-    grad = gradient(vi, model, spl)
-
     # Verify gradients; reject if gradients is NaN or Inf
+    # verifygrad(grad) || (pop!(vi.vals); pop!(vi.logp); p = p_old; break)
     verifygrad(grad) || (pop!(vi.vals); p = p_old; break)
 
     p -= ϵ * grad / 2

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -87,7 +87,7 @@ function find_good_eps{T}(model::Function, spl::Sampler{T}, vi::VarInfo)
     ϵ = 2.0^a * ϵ
     vi_prime, p_prime, τ = leapfrog(vi, p, 1, ϵ, model, spl)
     log_p_r_Θ′ = τ == 0 ? -Inf : -find_H(p_prime, model, vi_prime, spl)
-    dprintln(0, "a = $a, log_p_r_Θ′ = $log_p_r_Θ′")
+    dprintln(1, "a = $a, log_p_r_Θ′ = $log_p_r_Θ′")
   end
 
   println("\r[$T] found initial ϵ: ", ϵ)

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -27,10 +27,9 @@ function leapfrog(_vi, _p, τ, ϵ, model, spl)
   verifygrad(grad) || (return vi, p, 0)
 
   dprintln(2, "leapfrog stepping...")
-  τ_valid = 0
+  τ_valid = 0; p_old = deepcopy(p)
   for t in 1:τ        # do 'leapfrog' for each var
-    vi_old = deepcopy(vi)
-    p_old = deepcopy(p)
+    p_old[1:end] = p[1:end]
 
     p -= ϵ * grad / 2
 
@@ -43,13 +42,13 @@ function leapfrog(_vi, _p, τ, ϵ, model, spl)
       break
     elseif isnan(realpart(vi.logp)) || realpart(vi.logp) == Inf
       dwarn(0, "Numerical error: vi.lojoint = $(vi.logp)")
-      vi = vi_old; p = p_old; break
+      pop!(vi.vals); p = p_old; break
     end
 
     grad = gradient(vi, model, spl)
 
     # Verify gradients; reject if gradients is NaN or Inf
-    verifygrad(grad) || (vi = vi_old; p = p_old; break)
+    verifygrad(grad) || (pop!(vi.vals); p = p_old; break)
 
     p -= ϵ * grad / 2
 

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -1,14 +1,5 @@
 global Δ_max = 1000
 
-doc"""
-Calculate dot(θp - θm, r)
-"""
-function direction(θm, θp, r, spl)
-  rangesm = getranges(θm, spl)
-  rangesp = getranges(θp, spl)
-  dot(θp[rangesm] - θm[rangesp], r)
-end
-
 setchunksize(chun_size::Int) = global CHUNKSIZE = chunk_size
 
 function runmodel(model, _vi, spl, default_logp=0.0)

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -71,23 +71,25 @@ function find_good_eps{T}(model::Function, spl::Sampler{T}, vi::VarInfo)
   ϵ, p = 1.0, sample_momentum(vi, spl)    # set initial epsilon and momentums
   log_p_r_Θ = -find_H(p, model, vi, spl)  # calculate p(Θ, r) = exp(-H(Θ, r))
 
-  # Make a leapfrog step until accept
-  vi_prime, p_prime, τ_valid = leapfrog(vi, p, 1, ϵ, model, spl)
-  while τ_valid != 1
-    ϵ *= 0.5
-    vi_prime, p_prime, τ_valid = leapfrog(vi, p, 1, ϵ, model, spl)
-  end
-  ϵ_bar = ϵ
-  log_p_r_Θ′ = -find_H(p_prime, model, vi_prime, spl)   # calculate new p(Θ, p)
+  # # Make a leapfrog step until accept
+  # vi_prime, p_prime, τ_valid = leapfrog(vi, p, 1, ϵ, model, spl)
+  # while τ_valid == 0
+  #   ϵ *= 0.5
+  #   vi_prime, p_prime, τ_valid = leapfrog(vi, p, 1, ϵ, model, spl)
+  # end
+  # ϵ_bar = ϵ
+  vi_prime, p_prime, τ = leapfrog(vi, p, 1, ϵ, model, spl)
+  log_p_r_Θ′ = τ == 0 ? -Inf : -find_H(p_prime, model, vi_prime, spl)   # calculate new p(Θ, p)
 
   # Heuristically find optimal ϵ
   a = 2.0 * (log_p_r_Θ′ - log_p_r_Θ > log(0.5) ? 1 : 0) - 1
   while (exp(log_p_r_Θ′ - log_p_r_Θ))^a > 2.0^(-a)
     ϵ = 2.0^a * ϵ
-    vi_prime, p_prime, _ = leapfrog(vi, p, 1, ϵ, model, spl)
-    log_p_r_Θ′ = -find_H(p_prime, model, vi_prime, spl)
+    vi_prime, p_prime, τ = leapfrog(vi, p, 1, ϵ, model, spl)
+    log_p_r_Θ′ = τ == 0 ? -Inf : -find_H(p_prime, model, vi_prime, spl)
+    dprintln(0, "a = $a, log_p_r_Θ′ = $log_p_r_Θ′")
   end
 
-  println("[$T] found initial ϵ: ", ϵ)
-  ϵ_bar, ϵ
+  println("\r[$T] found initial ϵ: ", ϵ)
+  ϵ
 end


### PR DESCRIPTION
Fix #202 

- Leapfrog now returns partial (valid) trajectory when numerical error happens.
- NUTS: max_tree_depth is temporary set to 4 (larger tree_depth works, but very slow).

UPDATE

```julia
/=======================================================================
| Benchmark Result for >>> Naive Bayes <<<
|-----------------------------------------------------------------------
| Overview
|-----------------------------------------------------------------------
| Inference Engine  : NUTS(1000, 0.65)
| Time Used (s)     : 849.772136773
|   -> time by Stan : 7.94327
| Mem Alloc (bytes) : 73602458281
|-----------------------------------------------------------------------
| Turing Inference Result
|-----------------------------------------------------------------------
| >> phi[2] <<
| mean = [0.021,0.183,0.45,0.116,0.013,0.023,0.048,0.028,0.088,0.03]
|   -> Stan     = [0.022,0.179,0.452,0.116,0.014,0.022,0.049,0.029,0.085,0.031], diff = [0.001,0.004,0.002,0.0,0.0,0.0,0.002,0.001,0.003,0.001]
| >> phi[1] <<
| mean = [0.191,0.021,0.042,0.053,0.014,0.063,0.448,0.028,0.122,0.018]
|   -> Stan     = [0.192,0.021,0.043,0.052,0.015,0.064,0.445,0.028,0.121,0.018], diff = [0.001,0.0,0.001,0.0,0.0,0.001,0.003,0.0,0.0,0.0]
| >> phi[3] <<
| mean = [0.045,0.022,0.137,0.025,0.47,0.155,0.026,0.053,0.038,0.029]
|   -> Stan     = [0.045,0.023,0.143,0.026,0.461,0.157,0.026,0.055,0.036,0.029], diff = [0.0,0.001,0.006,0.0,0.008,0.002,0.0,0.001,0.003,0.0]
| >> phi[4] <<
| mean = [0.199,0.477,0.023,0.044,0.046,0.032,0.049,0.006,0.099,0.024]
|   -> Stan     = [0.202,0.474,0.025,0.044,0.05,0.032,0.049,0.007,0.093,0.025], diff = [0.003,0.003,0.002,0.0,0.003,0.001,0.0,0.0,0.006,0.001]
\=======================================================================

```