### PR TITLE
Unify step

### DIFF
--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -1,6 +1,6 @@
 import Base.string, Base.isequal, Base.==, Base.hash
 import Base.getindex, Base.setindex!, Base.push!
-import Base.rand, Base.show, Base.isnan
+import Base.rand, Base.show, Base.isnan, Base.isempty
 
 ###########
 # VarName #
@@ -83,6 +83,8 @@ getgid(vi::VarInfo, vn::VarName) = vi.gids[getidx(vi, vn)]
 setgid!(vi::VarInfo, gid::Int, vn::VarName) = vi.gids[getidx(vi, vn)] = gid
 
 istransformed(vi::VarInfo, vn::VarName) = vi.trans[getidx(vi, vn)]
+
+isempty(vi::VarInfo) = isempty(vi.idcs)
 
 # X -> R for all variables associated with given sampler
 function link(_vi::VarInfo, spl::Sampler)

--- a/src/samplers/gibbs.jl
+++ b/src/samplers/gibbs.jl
@@ -79,12 +79,7 @@ function sample(model::Function, alg::Gibbs)
           dprintln(2, "recording old θ...")
           varInfo = step(model, local_spl, varInfo, i==1)
           if ~spl.alg.thin
-            if isa(local_spl.alg, Hamiltonian) && ~local_spl.info[:accept_his][end]
-              samples[i_thin] = samples[i_thin - 1]
-            else
-              samples[i_thin].value = Sample(varInfo).value
-            end
-            i_thin += 1
+            samples[i_thin].value = Sample(varInfo).value; i_thin += 1
           end
         end
       else

--- a/src/samplers/gibbs.jl
+++ b/src/samplers/gibbs.jl
@@ -78,13 +78,7 @@ function sample(model::Function, alg::Gibbs)
 
         for _ = 1:local_spl.alg.n_iters
           dprintln(2, "recording old θ...")
-          old_vi = deepcopy(varInfo)
-          is_accept, varInfo = step(model, local_spl, varInfo, i==1)
-          if ~is_accept
-            # NOTE: this might cause problem if new variables is added to VarInfo,
-            #    which will add new elements to vi.idcs etc.
-            varInfo = old_vi
-          end
+          varInfo = step(model, local_spl, varInfo, i==1)
           if ~spl.alg.thin
             samples[i_thin].value = Sample(varInfo).value
             i_thin += 1

--- a/src/samplers/gibbs.jl
+++ b/src/samplers/gibbs.jl
@@ -100,7 +100,7 @@ function sample(model::Function, alg::Gibbs)
 
         # Local samples
         for _ = 1:local_spl.alg.n_iters
-          ref_particle, _ = step(model, local_spl, varInfo, ref_particle)
+          ref_particle = step(model, local_spl, varInfo, ref_particle)
           if ~spl.alg.thin
             samples[i_thin].value = Sample(ref_particle.vi).value
             i_thin += 1

--- a/src/samplers/gibbs.jl
+++ b/src/samplers/gibbs.jl
@@ -75,12 +75,6 @@ function sample(model::Function, alg::Gibbs)
       dprintln(2, "$(typeof(local_spl)) stepping...")
 
       if isa(local_spl.alg, GibbsComponent)
-        if isa(local_spl.alg, PG)
-          # Clean possible wrong counter from HMC
-          # NOTE: can we move this into PG step? (or we actually don't need it)
-          varInfo.index = 0; varInfo.num_produce = 0
-        end
-
         for _ = 1:local_spl.alg.n_iters
           dprintln(2, "recording old θ...")
           varInfo = step(model, local_spl, varInfo, i==1)

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -69,8 +69,13 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     spl.info[:H_bar] = 0.0
     spl.info[:m] = 0
 
-    true, vi_0
+    push!(spl.info[:accept_his], true)
+
+    vi_0
   else
+    dprintln(2, "recording old θ...")
+    old_vi = deepcopy(vi)
+
     # Set parameters
     δ = spl.alg.delta
     λ = spl.alg.lambda
@@ -124,10 +129,12 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     if spl.alg.gid != 0 vi = invlink(vi, spl); cleandual!(vi) end
 
     dprintln(2, "decide wether to accept...")
-    if rand() < α      # accepted
-      true, vi
-    else                                # rejected
-      false, vi
+    if rand() < α       # accepted
+      push!(spl.info[:accept_his], true)
+      vi
+    else                # rejected
+      push!(spl.info[:accept_his], false)
+      old_vi
     end
   end
 end

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -63,7 +63,9 @@ function step(model::Function, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
     spl.info[:H_bar] = 0.0
     spl.info[:m] = 0
 
-    true, vi_0
+    push!(spl.info[:accept_his], true)
+
+    vi_0
   else
     # Set parameters
     δ = spl.alg.delta
@@ -125,7 +127,9 @@ function step(model::Function, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
       spl.info[:ϵ] = spl.info[:ϵ_bar]
     end
 
-    true, vi_new
+    push!(spl.info[:accept_his], true)
+
+    vi_new
   end
 end
 

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -45,7 +45,9 @@ Sampler(alg::PG) = begin
   Sampler(alg, info)
 end
 
-function step(model::Function, spl::Sampler{PG}, vi::VarInfo)
+step(model::Function, spl::Sampler{PG}, vi::VarInfo, _::Bool) = step(model, spl, vi)
+
+step(model::Function, spl::Sampler{PG}, vi::VarInfo) = begin
   particles = ParticleContainer{TraceR}(model)
 
   ref_particle = isempty(vi) ?

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -65,9 +65,8 @@ function step(model::Function, spl::Sampler{PG}, vi::VarInfo, ref_particle)
   Ws, _ = weights(particles)
   indx = rand(Categorical(Ws))
   ref_particle = fork2(particles[indx])
-  s = getsample(particles, indx)
   push!(spl.info[:logevidence], particles.logE)
-  ref_particle, s
+  ref_particle
 end
 
 sample(model::Function, alg::PG) = begin
@@ -79,8 +78,8 @@ sample(model::Function, alg::PG) = begin
   ## re-inserts reteined particle after each resampling step
   ref_particle = nothing
   @showprogress 1 "[PG] Sampling..." for i = 1:n
-    ref_particle, s = step(model, spl, VarInfo(), ref_particle)
-    push!(samples, Sample(1/n, s.value))
+    ref_particle = step(model, spl, VarInfo(), ref_particle)
+    push!(samples, Sample(ref_particle.vi))
   end
 
   chain = Chain(exp(mean(spl.info[:logevidence])), samples)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,16 +72,16 @@ for (target, list) in testcases
     if ~ (t in testcases_excluded)
       if t in testcases_v04
         if VERSION < v"0.5"
-          println("[runtests.jl] \"$t.jl\" is running")
+          println("[runtests.jl] \"$target\\$t.jl\" is running")
           include(target*"/"t*".jl");
           # readstring(`julia $t.jl`)
-          println("[runtests.jl] \"$t.jl\" is successful")
+          println("[runtests.jl] \"$target\\$t.jl\" is successful")
         end
       else
-        println("[runtests.jl] \"$t.jl\" is running")
+        println("[runtests.jl] \"$target\\$t.jl\" is running")
         include(target*"/"t*".jl");
         # readstring(`julia $t.jl`)
-        println("[runtests.jl] \"$t.jl\" is successful")
+        println("[runtests.jl] \"$target\\$t.jl\" is successful")
       end
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,16 +72,16 @@ for (target, list) in testcases
     if ~ (t in testcases_excluded)
       if t in testcases_v04
         if VERSION < v"0.5"
-          println("[runtests.jl] \"$target\\$t.jl\" is running")
+          println("[runtests.jl] \"$target/$t.jl\" is running")
           include(target*"/"t*".jl");
           # readstring(`julia $t.jl`)
-          println("[runtests.jl] \"$target\\$t.jl\" is successful")
+          println("[runtests.jl] \"$target/$t.jl\" is successful")
         end
       else
-        println("[runtests.jl] \"$target\\$t.jl\" is running")
+        println("[runtests.jl] \"$target/$t.jl\" is running")
         include(target*"/"t*".jl");
         # readstring(`julia $t.jl`)
-        println("[runtests.jl] \"$target\\$t.jl\" is successful")
+        println("[runtests.jl] \"$target/$t.jl\" is successful")
       end
     end
   end

--- a/test/varinfo.jl/varinfo.jl
+++ b/test/varinfo.jl/varinfo.jl
@@ -1,6 +1,6 @@
 using Turing, Base.Test
 using Turing: uid, cuid, reconstruct, invlink, getvals, step, getidcs, getretain, NULL
-
+include("../utility.jl")
 # Test for uid() (= string())
 csym = gensym()
 vn1 = VarName(csym, :x, "[1]", 1)
@@ -75,9 +75,7 @@ g = Sampler(Gibbs(1000, PG(10, 2, :x, :y, :z), HMC(1, 0.4, 8, :w, :u)))
 pg, hmc = g.info[:samplers]
 
 vi = g_demo_f()
-
-ref_particle = step(g_demo_f, pg, vi, nothing)
-vi = ref_particle.vi
+vi = step(g_demo_f, pg, vi)
 @test vi.gids == [1,1,1,0,0]
 
 vi = g_demo_f(vi=vi, sampler=hmc)

--- a/test/varinfo.jl/varinfo.jl
+++ b/test/varinfo.jl/varinfo.jl
@@ -76,7 +76,7 @@ pg, hmc = g.info[:samplers]
 
 vi = g_demo_f()
 
-ref_particle, s = step(g_demo_f, pg, vi, nothing)
+ref_particle = step(g_demo_f, pg, vi, nothing)
 vi = ref_particle.vi
 @test vi.gids == [1,1,1,0,0]
 


### PR DESCRIPTION
Address last two unsolved points in https://github.com/yebai/Turing.jl/issues/107

The `step` function for both PG and HMC only returns an object of `VarInfo` now:
- For HMC, I removed the return `true`/`false` value to indicate but store the accept history in `spl.info[:accept_his]` with in the `step` function
- For PG, there were two return variables: `ref_particle` and `samples`
  1. `samples` is easy to remove as it just the samples in `ref_particle`
  2. `ref_particle` is removed by re-created the particle (`fork2(TracR(...))`) using the corresponding `vi`
      - I noticed that in the original code `fork2` always clean up `vi` - does it means the reference particle is always a "new" one?