### PR TITLE
Reduce deepcopy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
          env: GROUP=MOC
        - os: osx
          env: GROUP=SV
-         
+
     allow_failures:
        - env: GROUP=Test
          os: osx

--- a/benchmarks/benchmark.jl
+++ b/benchmarks/benchmark.jl
@@ -6,14 +6,14 @@ using Stan
 CONFIG = Dict(
   "model-list" => [
     "gdemo-geweke",
-    "MoC",
+    # "MoC",
     #"normal-loc",
     "normal-mixture",
-    "simplegauss",
+    "gdemo",
     "gauss",
     "bernoulli",
     #"negative-binomial",
-    "lda"
+    # "lda"
   ],
 
   "test-level" => 2   # 1 = model lang, 2 = whole interface

--- a/benchmarks/benchmark.jl
+++ b/benchmarks/benchmark.jl
@@ -6,7 +6,7 @@ using Stan
 CONFIG = Dict(
   "model-list" => [
     "gdemo-geweke",
-    "naive.bayes",
+    "MoC",
     #"normal-loc",
     "normal-mixture",
     "simplegauss",

--- a/benchmarks/bernoulli-stan.run.jl
+++ b/benchmarks/bernoulli-stan.run.jl
@@ -4,7 +4,7 @@ using Stan
 
 include(Pkg.dir("Turing")*"/benchmarks/benchmarkhelper.jl")
 include(Pkg.dir("Turing")*"/example-models/stan-models/bernoulli-stan.data.jl")
-include(Pkg.dir("Turing")*"/example-models/stan-models/bernoulli-stan..model.jl")
+include(Pkg.dir("Turing")*"/example-models/stan-models/bernoulli-stan.model.jl")
 
 stan_model_name = "bernoulli"
 berstan = Stanmodel(name=stan_model_name, model=berstanmodel, nchains=1);

--- a/benchmarks/bernoulli.run.jl
+++ b/benchmarks/bernoulli.run.jl
@@ -4,7 +4,7 @@ using Stan
 
 include(Pkg.dir("Turing")*"/benchmarks/benchmarkhelper.jl")
 include(Pkg.dir("Turing")*"/example-models/stan-models/bernoulli.data.jl")
-include(Pkg.dir("Turing")*"/example-models/stan-models/bernoulli..model.jl")
+include(Pkg.dir("Turing")*"/example-models/stan-models/bernoulli.model.jl")
 
 bench_res = tbenchmark("HMC(1000, 0.25, 5)", "bermodel", "berdata")
 logd = build_logd("Bernoulli Model", bench_res...)

--- a/benchmarks/lda.run.jl
+++ b/benchmarks/lda.run.jl
@@ -8,6 +8,8 @@ include(Pkg.dir("Turing")*"/example-models/stan-models/lda.model.jl")
 
 include(Pkg.dir("Turing")*"/benchmarks/"*"lda-stan.run.jl")
 
+setchunksize(60)
+
 for alg in ["HMC(1000, 0.25, 6)", "HMCDA(1000, 0.65, 1.5)"]
   bench_res = tbenchmark(alg, "ldamodel", "data=ldastandata[1]")
   bench_res[4].names = ["phi[1]", "phi[2]"]

--- a/benchmarks/lda.run.jl
+++ b/benchmarks/lda.run.jl
@@ -6,12 +6,13 @@ include(Pkg.dir("Turing")*"/benchmarks/benchmarkhelper.jl")
 include(Pkg.dir("Turing")*"/example-models/stan-models/lda-stan.data.jl")
 include(Pkg.dir("Turing")*"/example-models/stan-models/lda.model.jl")
 
-bench_res = tbenchmark("HMCDA(1000, 0.65, 1.5)", "ldamodel", "data=ldastandata[1]")
-bench_res[4].names = ["phi[1]", "phi[2]"]
-logd = build_logd("LDA", bench_res...)
-
 include(Pkg.dir("Turing")*"/benchmarks/"*"lda-stan.run.jl")
-logd["stan"] = lda_stan_d
-logd["time_stan"] = lda_time
 
-print_log(logd)
+for alg in ["HMC(1000, 0.25, 6)", "HMCDA(1000, 0.65, 1.5)"]
+  bench_res = tbenchmark(alg, "ldamodel", "data=ldastandata[1]")
+  bench_res[4].names = ["phi[1]", "phi[2]"]
+  logd = build_logd("LDA", bench_res...)
+  logd["stan"] = lda_stan_d
+  logd["time_stan"] = lda_time
+  print_log(logd)
+end

--- a/example-models/benchmarks/gauss.model.jl
+++ b/example-models/benchmarks/gauss.model.jl
@@ -1,6 +1,6 @@
 @model gaussmodel(x) = begin
     N = length(x)
-    lam = tzeros(Float64,N)
+    lam = tzeros(Real,N)
     mu ~ Normal(0, sqrt(1000));
     for i = 1:N
       lam[i] ~ Gamma(1, 1)

--- a/example-models/stan-models/MoC.model.jl
+++ b/example-models/stan-models/MoC.model.jl
@@ -1,5 +1,5 @@
 # Turing.jl version of model at https://github.com/stan-dev/example-models/blob/master/misc/cluster/naive-bayes/naive-bayes.stan
-
+# Reference: http://mlg.eng.cam.ac.uk/teaching/4f13/1617/document%20models.pdf
 @model nbmodel(K, V, M, N, z, w, doc, alpha, beta) = begin
   theta ~ Dirichlet(alpha)
   phi = Array{Any}(K)

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -51,10 +51,7 @@ gradient2(vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
 
   # Chunk-wise forward AD
   for (vn_chunk, chunk_dim) in vn_chunks
-    expand!(vi) # NOTE: place where calling gradient should
-                #       be responsible for clean up the vals
-
-    # Set dual part correspondingly
+    # 1. Set dual part correspondingly
     dprintln(4, "set dual...")
     dps = zeros(chunk_dim)
 
@@ -76,8 +73,9 @@ gradient2(vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
         vi[range] = map(r -> Dual{chunk_dim, Float64}(r), reals)
       end
     end
+    
+    # 2. Run model and collect gradient
     vi = runmodel(model, vi, spl)
-    # Collect gradient
     dprintln(4, "collect gradients from logp...")
     append!(grad, collect(dualpart(-getlogp(vi))))
   end

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -10,7 +10,7 @@ grad = gradient(vi, model, spl)
 end
 ```
 """
-gradient(_vi::VarInfo, model::Function) = gradient(_vi, model, nothing)
+gradient(vi::VarInfo, model::Function) = gradient(vi, model, nothing)
 gradient(_vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
 
   vi = deepcopy(_vi)
@@ -26,9 +26,10 @@ gradient(_vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
   g(vi[spl])
 end
 
-gradient2(_vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
+gradient2(vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
   # Initialisation
-  vi = deepcopy(_vi); grad = Vector{Float64}()
+  expand!(vi)
+  grad = Vector{Float64}()
 
   # Split keys(vi) into chunks,
   dprintln(4, "making chunks...")

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -17,7 +17,7 @@ gradient(_vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
 
   f(x::Vector) = begin
     vi[spl] = x
-    -runmodel(model, vi, spl).logp
+    -getlogp(runmodel(model, vi, spl))
   end
 
   g = x -> ForwardDiff.gradient(f, x::Vector,
@@ -77,7 +77,7 @@ gradient2(_vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
     vi = runmodel(model, vi, spl)
     # Collect gradient
     dprintln(4, "collect gradients from logp...")
-    append!(grad, collect(dualpart(-vi.logp)))
+    append!(grad, collect(dualpart(-getlogp(vi))))
   end
 
   grad

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -10,7 +10,7 @@ grad = gradient(vi, model, spl)
 end
 ```
 """
-gradient(vi::VarInfo, model::Function) = gradient(vi, model, nothing)
+gradient(vi::VarInfo, model::Function) = gradient2(vi, model, nothing)
 gradient(_vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
 
   vi = deepcopy(_vi)
@@ -51,8 +51,8 @@ gradient2(vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
 
   # Chunk-wise forward AD
   for (key_chunk, prior_dim) in prior_key_chunks
-    expand!(vi)
-    
+    expand!(vi) # NOTE: place where calling gradient should
+                #       be responsible for clean up the vals
     # Set dual part correspondingly
     dprintln(4, "set dual...")
     dps = zeros(prior_dim)

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -28,7 +28,7 @@ end
 
 gradient2(vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
 
-  θ = vi[spl]
+  θ = realpart(vi[spl])
   if spl != nothing && haskey(spl.info, :grad_cache)
     if haskey(spl.info[:grad_cache], θ)
       return spl.info[:grad_cache][θ]

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -53,15 +53,12 @@ gradient2(vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
   for (vn_chunk, chunk_dim) in vn_chunks
     expand!(vi) # NOTE: place where calling gradient should
                 #       be responsible for clean up the vals
+
     # Set dual part correspondingly
     dprintln(4, "set dual...")
     dps = zeros(chunk_dim)
+
     dim_count = 1
-
-    # vns = filter(vn -> vn in vn_chunk, vns_all)
-    # ranges = union(map(vn -> getrange(vi, vn), vns)...)
-    # vi[ranges] =
-
     for k in vns_all
       l = length(getrange(vi, k))
       reals = realpart(getval(vi, k))

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -32,46 +32,51 @@ gradient2(vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
 
   # Split keys(vi) into chunks,
   dprintln(4, "making chunks...")
-  prior_key_chunks = []; key_chunk = []; prior_dim = 0
+  vn_chunks = []; vn_chunk = []; chunk_dim = 0
 
-  gkeys = getvns(vi, spl)
-  for k in gkeys
+  vns_all = getvns(vi, spl)
+  for k in vns_all
     l = length(getrange(vi, k))         # dimension for the current variable
-    if prior_dim + l > CHUNKSIZE
-      push!(prior_key_chunks, # store the previous chunk
-            (key_chunk, prior_dim))
-      key_chunk = []          # initialise a new chunk
-      prior_dim = 0           # reset dimension counter
+    if chunk_dim + l > CHUNKSIZE
+      push!(vn_chunks, # store the previous chunk
+            (vn_chunk, chunk_dim))
+      vn_chunk = []          # initialise a new chunk
+      chunk_dim = 0           # reset dimension counter
     end
-    push!(key_chunk, k)       # put the current variable into the current chunk
-    prior_dim += l            # update dimension counter
+    push!(vn_chunk, k)       # put the current variable into the current chunk
+    chunk_dim += l            # update dimension counter
   end
-  push!(prior_key_chunks,     # push the last chunk
-        (key_chunk, prior_dim))
+  push!(vn_chunks,     # push the last chunk
+        (vn_chunk, chunk_dim))
 
   # Chunk-wise forward AD
-  for (key_chunk, prior_dim) in prior_key_chunks
+  for (vn_chunk, chunk_dim) in vn_chunks
     expand!(vi) # NOTE: place where calling gradient should
                 #       be responsible for clean up the vals
     # Set dual part correspondingly
     dprintln(4, "set dual...")
-    dps = zeros(prior_dim)
-    prior_count = 1
-    for k in gkeys
+    dps = zeros(chunk_dim)
+    dim_count = 1
+
+    # vns = filter(vn -> vn in vn_chunk, vns_all)
+    # ranges = union(map(vn -> getrange(vi, vn), vns)...)
+    # vi[ranges] =
+
+    for k in vns_all
       l = length(getrange(vi, k))
       reals = realpart(getval(vi, k))
       range = getrange(vi, k)
-      if k in key_chunk         # for each variable to compute gradient in this round
+      if k in vn_chunk         # for each variable to compute gradient in this round
         dprintln(5, "making dual...")
         for i = 1:l
-          dps[prior_count] = 1  # set dual part
+          dps[dim_count] = 1  # set dual part
           vi[range[i]] = ForwardDiff.Dual(reals[i], dps...)
-          dps[prior_count] = 0  # reset dual part
-          prior_count += 1      # count
+          dps[dim_count] = 0  # reset dual part
+          dim_count += 1      # count
         end
         dprintln(5, "make dual done")
       else                      # for other varilables (no gradient in this round)
-        vi[range] = map(r -> Dual{prior_dim, Float64}(r), reals)
+        vi[range] = map(r -> Dual{chunk_dim, Float64}(r), reals)
       end
     end
     vi = runmodel(model, vi, spl)

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -28,7 +28,6 @@ end
 
 gradient2(vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
   # Initialisation
-  expand!(vi)
   grad = Vector{Float64}()
 
   # Split keys(vi) into chunks,
@@ -52,8 +51,8 @@ gradient2(vi::VarInfo, model::Function, spl::Union{Void, Sampler}) = begin
 
   # Chunk-wise forward AD
   for (key_chunk, prior_dim) in prior_key_chunks
-    expand!(vi)    # NOTE: we don't have to call last in the end
-                      #       because we don't return the amended VarInfo
+    expand!(vi)
+    
     # Set dual part correspondingly
     dprintln(4, "set dual...")
     dps = zeros(prior_dim)

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -58,12 +58,22 @@ macro ~(left, right)
           csym_str = string(Turing._compiler_[:fname])*"_var"* string(@__LINE__)
           sym = Symbol($(string(left)))
           vn = Turing.VarName(vi, Symbol(csym_str), sym, "")
-          $(left) = Turing.assume(
-            sampler,
-            $(right),   # dist
-            vn,         # VarName
-            vi          # VarInfo
-          )
+          if isa($(right), Vector)
+            $(left) = Turing.assume(
+              sampler,
+              $(right),   # dist
+              vn,         # VarName
+              $(left),
+              vi          # VarInfo
+            )
+          else
+            $(left) = Turing.assume(
+              sampler,
+              $(right),   # dist
+              vn,         # VarName
+              vi          # VarInfo
+            )
+          end
         end
       else
         # Indexing

--- a/src/core/container.jl
+++ b/src/core/container.jl
@@ -37,18 +37,19 @@ function Base.push!(pc :: ParticleContainer, p :: Particle)
 end
 Base.push!(pc :: ParticleContainer) = Base.push!(pc, eltype(pc.vals)(pc.model))
 
-function Base.push!(pc :: ParticleContainer, n :: Int)
-  vals = Array{eltype(pc.vals), 1}(n)
-  logWs = Array{eltype(pc.logWs), 1}(n)
-  for i=1:n
-    vals[i]  = eltype(pc.vals)(pc.model)
-    logWs[i] = 0
-  end
-  append!(pc.vals, vals)
-  append!(pc.logWs, logWs)
-  pc.num_particles += n
-  pc
-end
+# NOTE: Function to remove.
+# function Base.push!(pc :: ParticleContainer, n :: Int)
+#   vals = Array{eltype(pc.vals), 1}(n)
+#   logWs = Array{eltype(pc.logWs), 1}(n)
+#   for i=1:n
+#     vals[i]  = eltype(pc.vals)(pc.model)
+#     logWs[i] = 0
+#   end
+#   append!(pc.vals, vals)
+#   append!(pc.logWs, logWs)
+#   pc.num_particles += n
+#   pc
+# end
 
 function Base.push!(pc :: ParticleContainer, n :: Int, spl, varInfo)
   vals = Array{eltype(pc.vals), 1}(n)

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -38,7 +38,7 @@ type VarInfo
   vals        ::    Vector{Vector{Real}}
   dists       ::    Vector{Distribution}
   gids        ::    Vector{Int}   # group ids
-  trans       ::    Vector{Bool}
+  trans       ::    Vector{Vector{Bool}}
   logp        ::    Real          # NOTE: logp should be a vector.
   logw        ::    Real          # NOTE: importance weight when sampling from the prior.
   index       ::    Int           # index of current randomness
@@ -50,7 +50,7 @@ type VarInfo
     Vector{Vector{Real}}(),
     Vector{Distribution}(),
     Vector{Int}(),
-    Vector{Bool}(),
+    Vector{Vector{Bool}}(),
     0.0,0.0,
     0,
     0
@@ -81,8 +81,8 @@ getgid(vi::VarInfo, vn::VarName) = vi.gids[getidx(vi, vn)]
 
 setgid!(vi::VarInfo, gid::Int, vn::VarName) = vi.gids[getidx(vi, vn)] = gid
 
-istrans(vi::VarInfo, vn::VarName) = vi.trans[getidx(vi, vn)]
-settrans!(vi::VarInfo, trans::Bool, vn::VarName) = vi.trans[getidx(vi, vn)] = trans
+istrans(vi::VarInfo, vn::VarName) = vi.trans[end][getidx(vi, vn)]
+settrans!(vi::VarInfo, trans::Bool, vn::VarName) = vi.trans[end][getidx(vi, vn)] = trans
 
 isempty(vi::VarInfo) = isempty(vi.idcs)
 
@@ -175,6 +175,7 @@ push!(vi::VarInfo, vn::VarName, r::Any, dist::Distribution, gid::Int) = begin
   @assert ~(vn in vns(vi)) "[push!] attempt to add an exisitng variable $(sym(vn)) ($(vn)) to VarInfo (keys=$(keys(vi))) with dist=$dist, gid=$gid"
 
   if isempty(vi.vals) push!(vi.vals, Vector{Real}()) end
+  if isempty(vi.trans) push!(vi.trans, Vector{Bool}()) end
 
   val = vectorize(dist, r)
 
@@ -185,7 +186,7 @@ push!(vi::VarInfo, vn::VarName, r::Any, dist::Distribution, gid::Int) = begin
   append!(vi.vals[end], val)
   push!(vi.dists, dist)
   push!(vi.gids, gid)
-  push!(vi.trans, false)
+  push!(vi.trans[end], false)
 
   vi
 end

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -209,7 +209,6 @@ getidcs(vi::VarInfo, spl::Sampler) = begin
   # NOTE: 0b00 is the sanity flag for
   #         |\____ getidcs   (mask = 0b10)
   #         \_____ getranges (mask = 0b01)
-  # TODO: set these as constants
   if ~haskey(spl.info, :cache_updated) spl.info[:cache_updated] = CACHERESET end
   if haskey(spl.info, :idcs) && (spl.info[:cache_updated] & CACHEIDCS) > 0
     spl.info[:idcs]

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -73,7 +73,6 @@ setval!(vi::VarInfo, val::Any, view::Vector{UnitRange}) = map(v->vi.vals[end][v]
 getall(vi::VarInfo)            = vi.vals[end]
 setall!(vi::VarInfo, val::Any) = vi.vals[end] = val
 
-
 getsym(vi::VarInfo, vn::VarName) = vi.vns[getidx(vi, vn)].sym
 
 getdist(vi::VarInfo, vn::VarName) = vi.dists[getidx(vi, vn)]
@@ -201,11 +200,7 @@ end
 #################################
 
 expand!(vi::VarInfo) = push!(vi.vals, deepcopy(vi.vals[end]))
-last(_vi::VarInfo) = begin
-  vi = deepcopy(_vi)
-  splice!(vi.vals, 1:length(vi.vals)-1)
-  vi
-end
+last!(vi::VarInfo) = splice!(vi.vals, 1:length(vi.vals)-1)
 
 # Get all indices of variables belonging to gid or 0
 getidcs(vi::VarInfo) = getidcs(vi, nothing)

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -97,30 +97,22 @@ acclogp!(vi::VarInfo, logp::Real) = vi.logp[end] += logp
 isempty(vi::VarInfo) = isempty(vi.idcs)
 
 # X -> R for all variables associated with given sampler
-function link(vi::VarInfo, spl::Sampler)
-  expand!(vi)
-  gvns = getvns(vi, spl)
-  for vn in gvns
+link!(vi::VarInfo, spl::Sampler) =
+  for vn in getvns(vi, spl)
     dist = getdist(vi, vn)
     setval!(vi, vectorize(dist, link(dist, reconstruct(dist, getval(vi, vn)))), vn)
     settrans!(vi, true, vn)
+    setlogp!(vi, zero(Real))
   end
-  last!(vi)
-  vi
-end
 
 # R -> X for all variables associated with given sampler
-function invlink(vi::VarInfo, spl::Sampler)
-  expand!(vi)
-  gvns = getvns(vi, spl)
-  for vn in gvns
+invlink!(vi::VarInfo, spl::Sampler) =
+  for vn in getvns(vi, spl)
     dist = getdist(vi, vn)
     setval!(vi, vectorize(dist, invlink(dist, reconstruct(dist, getval(vi, vn)))), vn)
     settrans!(vi, false, vn)
+    setlogp!(vi, zero(Real))
   end
-  last!(vi)
-  vi
-end
 
 function cleandual!(vi::VarInfo)
   for vn in keys(vi)

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -209,9 +209,8 @@ expand!(vi::VarInfo) = begin
 end
 
 last!(vi::VarInfo) = begin
-  # QUESTION: is splice! slow?
-  splice!(vi.vals, 1:length(vi.vals)-1)
-  splice!(vi.trans, 1:length(vi.trans)-1)
+  vi.vals = [vi.vals[end]]
+  vi.trans = [vi.trans[end]]
 end
 
 # Get all indices of variables belonging to gid or 0

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -204,11 +204,12 @@ end
 #################################
 
 expand!(vi::VarInfo) = begin
-  push!(vi.vals, deepcopy(vi.vals[end]))
+  push!(vi.vals, realpart(vi.vals[end]))
   push!(vi.trans, deepcopy(vi.trans[end]))
 end
 
 last!(vi::VarInfo) = begin
+  # QUESTION: is splice! slow?
   splice!(vi.vals, 1:length(vi.vals)-1)
   splice!(vi.trans, 1:length(vi.trans)-1)
 end

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -81,7 +81,8 @@ getgid(vi::VarInfo, vn::VarName) = vi.gids[getidx(vi, vn)]
 
 setgid!(vi::VarInfo, gid::Int, vn::VarName) = vi.gids[getidx(vi, vn)] = gid
 
-istransformed(vi::VarInfo, vn::VarName) = vi.trans[getidx(vi, vn)]
+istrans(vi::VarInfo, vn::VarName) = vi.trans[getidx(vi, vn)]
+settrans!(vi::VarInfo, trans::Bool, vn::VarName) = vi.trans[getidx(vi, vn)] = trans
 
 isempty(vi::VarInfo) = isempty(vi.idcs)
 
@@ -92,7 +93,7 @@ function link(_vi::VarInfo, spl::Sampler)
   for vn in gvns
     dist = getdist(vi, vn)
     setval!(vi, vectorize(dist, link(dist, reconstruct(dist, getval(vi, vn)))), vn)
-    vi.trans[getidx(vi, vn)] = true
+    settrans!(vi, true, vn)
   end
   vi
 end
@@ -104,7 +105,7 @@ function invlink(_vi::VarInfo, spl::Sampler)
   for vn in gvns
     dist = getdist(vi, vn)
     setval!(vi, vectorize(dist, invlink(dist, reconstruct(dist, getval(vi, vn)))), vn)
-    vi.trans[getidx(vi, vn)] = false
+    settrans!(vi, false, vn)
   end
   vi
 end
@@ -127,7 +128,7 @@ Base.getindex(vi::VarInfo, vn::VarName) = begin
   @assert haskey(vi, vn) "[Turing] attempted to replay unexisting variables in VarInfo"
   dist = getdist(vi, vn)
   r = reconstruct(dist, getval(vi, vn))
-  r = istransformed(vi, vn) ? invlink(dist, r) : r
+  r = istrans(vi, vn) ? invlink(dist, r) : r
 end
 
 # Base.setindex!(vi::VarInfo, r, vn::VarName) = begin

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -97,22 +97,24 @@ acclogp!(vi::VarInfo, logp::Real) = vi.logp[end] += logp
 isempty(vi::VarInfo) = isempty(vi.idcs)
 
 # X -> R for all variables associated with given sampler
-link!(vi::VarInfo, spl::Sampler) =
+link!(vi::VarInfo, spl::Sampler) = begin
   for vn in getvns(vi, spl)
     dist = getdist(vi, vn)
     setval!(vi, vectorize(dist, link(dist, reconstruct(dist, getval(vi, vn)))), vn)
     settrans!(vi, true, vn)
-    setlogp!(vi, zero(Real))
   end
+  setlogp!(vi, zero(Real))
+end
 
 # R -> X for all variables associated with given sampler
-invlink!(vi::VarInfo, spl::Sampler) =
+invlink!(vi::VarInfo, spl::Sampler) = begin
   for vn in getvns(vi, spl)
     dist = getdist(vi, vn)
     setval!(vi, vectorize(dist, invlink(dist, reconstruct(dist, getval(vi, vn)))), vn)
     settrans!(vi, false, vn)
-    setlogp!(vi, zero(Real))
   end
+  setlogp!(vi, zero(Real))
+end
 
 function cleandual!(vi::VarInfo)
   for vn in keys(vi)

--- a/src/samplers/gibbs.jl
+++ b/src/samplers/gibbs.jl
@@ -75,6 +75,10 @@ function sample(model::Function, alg::Gibbs)
       dprintln(2, "$(typeof(local_spl)) stepping...")
 
       if isa(local_spl.alg, GibbsComponent)
+        if isa(local_spl.alg, Hamiltonian)  # clean cache
+          local_spl.info[:grad_cache] = Dict{Vector,Vector}()
+        end
+
         for _ = 1:local_spl.alg.n_iters
           dprintln(2, "recording old θ...")
           varInfo = step(model, local_spl, varInfo, i==1)

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -121,5 +121,8 @@ function assume{T<:Hamiltonian}(spl::Sampler{T}, dist::Distribution, vn::VarName
   r
 end
 
-observe{T<:Hamiltonian}(spl::Sampler{T}, d::Distribution, value::Any, vi::VarInfo) =
-  observe(nothing, d, value, vi)  
+observe{A<:Hamiltonian}(spl::Sampler{A}, d::Distribution, value::Any, vi::VarInfo) =
+  observe(nothing, d, value, vi)
+
+observe{A<:Hamiltonian,D<:Distribution}(spl::Sampler{A}, ds::Vector{D}, value::Any, vi::VarInfo) =
+  observe(nothing, ds, value, vi)

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -101,11 +101,11 @@ function assume{T<:Hamiltonian}(spl::Sampler{T}, dist::Distribution, vn::VarName
   dprintln(2, "assuming...")
   updategid!(vi, vn, spl)
   r = vi[vn]
-  vi.logp += logpdf(dist, r, istrans(vi, vn))
+  acclogp!(vi, logpdf(dist, r, istrans(vi, vn)))
   r
 end
 
 function observe{T<:Hamiltonian}(spl::Sampler{T}, d::Distribution, value::Any, vi::VarInfo)
   dprintln(2, "observing...")
-  vi.logp += logpdf(d, map(x -> Dual(x), value))
+  acclogp!(vi, logpdf(d, map(x -> Dual(x), value)))
 end

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -52,6 +52,7 @@ Sampler(alg::Hamiltonian) = begin
   info[:accept_his] = []
   info[:lf_num] = 0
   info[:eval_num] = 0
+  info[:grad_cache] = Dict{Vector,Vector}()
   Sampler(alg, info)
 end
 

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -71,7 +71,6 @@ function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
   for i = 1:n
     samples[i] = Sample(weight, Dict{Symbol, Any}())
   end
-  accept_num = 0  # record the accept number
   vi = model()
 
   if spl.alg.gid == 0 link!(vi, spl) end
@@ -90,7 +89,7 @@ function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
   end
 
   if ~isa(alg, NUTS)  # cccept rate for NUTS is meaningless - so no printing
-    accept_rate = accept_num / n  # calculate the accept rate
+    accept_rate = sum(spl.info[:accept_his]) / n  # calculate the accept rate
     println("[$alg_str] Done with accept rate = $accept_rate.")
   end
 

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -96,9 +96,9 @@ function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
   if ~isa(alg, NUTS)  # cccept rate for NUTS is meaningless - so no printing
     accept_rate = sum(spl.info[:accept_his]) / n  # calculate the accept rate
     log_str = """
-    [$alg_str] Done with accept rate     = $accept_rate;
-                         #lf / sample    = $(spl.info[:lf_num] / n);
-                         #evals / sample = $(spl.info[:eval_num] / n).
+[$alg_str] Done with accept rate     = $accept_rate;
+                     #lf / sample    = $(spl.info[:lf_num] / n);
+                     #evals / sample = $(spl.info[:eval_num] / n).
     """
     println(log_str)
   end

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -121,7 +121,5 @@ function assume{T<:Hamiltonian}(spl::Sampler{T}, dist::Distribution, vn::VarName
   r
 end
 
-function observe{T<:Hamiltonian}(spl::Sampler{T}, d::Distribution, value::Any, vi::VarInfo)
-  dprintln(2, "observing...")
-  acclogp!(vi, logpdf(d, map(x -> Dual(x), value)))
-end
+observe{T<:Hamiltonian}(spl::Sampler{T}, d::Distribution, value::Any, vi::VarInfo) =
+  observe(nothing, d, value, vi)  

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -74,7 +74,7 @@ function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
   accept_num = 0  # record the accept number
   vi = model()
 
-  if spl.alg.gid == 0 vi = link(vi, spl) end
+  if spl.alg.gid == 0 link!(vi, spl) end
 
   # HMC steps
   spl.info[:progress] = ProgressMeter.Progress(n, 1, "[$alg_str] Sampling...", 0)

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -50,6 +50,8 @@ end
 Sampler(alg::Hamiltonian) = begin
   info=Dict{Symbol, Any}()
   info[:accept_his] = []
+  info[:lf_num] = 0
+  info[:eval_num] = 0
   Sampler(alg, info)
 end
 
@@ -93,7 +95,12 @@ function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
 
   if ~isa(alg, NUTS)  # cccept rate for NUTS is meaningless - so no printing
     accept_rate = sum(spl.info[:accept_his]) / n  # calculate the accept rate
-    println("[$alg_str] Done with accept rate = $accept_rate.")
+    log_str = """
+    [$alg_str] Done with accept rate     = $accept_rate;
+                         #lf / sample    = $(spl.info[:lf_num] / n);
+                         #evals / sample = $(spl.info[:eval_num] / n).
+    """
+    println(log_str)
   end
 
   Chain(0, samples)    # wrap the result by Chain

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -73,7 +73,10 @@ function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
   end
   vi = model()
 
-  if spl.alg.gid == 0 link!(vi, spl) end
+  if spl.alg.gid == 0
+    link!(vi, spl)
+    runmodel(model, vi, spl)
+  end
 
   # HMC steps
   spl.info[:progress] = ProgressMeter.Progress(n, 1, "[$alg_str] Sampling...", 0)

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -60,7 +60,9 @@ sample(model::Function, alg::Hamiltonian) = sample(model, alg, CHUNKSIZE)
 # NOTE: in the previous code, `sample` would call `run`; this is
 # now simplified: `sample` and `run` are merged into one function.
 function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
-  global CHUNKSIZE = chunk_size;
+  default_chunk_size = CHUNKSIZE
+  global CHUNKSIZE = chunk_size
+
   spl = Sampler(alg);
   alg_str = isa(alg, HMC)   ? "HMC"   :
             isa(alg, HMCDA) ? "HMCDA" :
@@ -102,6 +104,8 @@ function sample{T<:Hamiltonian}(model::Function, alg::T, chunk_size::Int)
     """
     println(log_str)
   end
+
+  global CHUNKSIZE = default_chunk_size
 
   Chain(0, samples)    # wrap the result by Chain
 end

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -101,7 +101,7 @@ function assume{T<:Hamiltonian}(spl::Sampler{T}, dist::Distribution, vn::VarName
   dprintln(2, "assuming...")
   updategid!(vi, vn, spl)
   r = vi[vn]
-  vi.logp += logpdf(dist, r, istransformed(vi, vn))
+  vi.logp += logpdf(dist, r, istrans(vi, vn))
   r
 end
 

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -125,10 +125,10 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     dprintln(2, "decide wether to accept...")
     if rand() < α       # accepted
       push!(spl.info[:accept_his], true)
-      vi
     else                # rejected
       push!(spl.info[:accept_his], false)
-      old_vi
+      vi = old_vi
     end
+    vi
   end
 end

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -49,16 +49,10 @@ end
 
 function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
   if is_first
-    vi_0 = deepcopy(vi)
-
     if spl.alg.delta > 0
-
-      dprintln(3, "X -> R...")
-      if spl.alg.gid != 0 link!(vi, spl) end
-
-      # Heuristically find optimal ϵ
-      ϵ = find_good_eps(model, spl, vi)
-
+      if spl.alg.gid != 0 link!(vi, spl) end      # X -> R
+      ϵ = find_good_eps(model, spl, vi)           # heuristically find optimal ϵ
+      if spl.alg.gid != 0 invlink!(vi, spl) end   # R -> X
     else
       ϵ = spl.info[:ϵ][end]
     end
@@ -71,7 +65,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
 
     push!(spl.info[:accept_his], true)
 
-    vi_0
+    vi
   else
     dprintln(2, "recording old θ...")
     old_vi = deepcopy(vi)

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -54,7 +54,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     if spl.alg.delta > 0
 
       dprintln(3, "X -> R...")
-      if spl.alg.gid != 0 vi = link(vi, spl) end
+      if spl.alg.gid != 0 link!(vi, spl) end
 
       # Heuristically find optimal ϵ
       ϵ = find_good_eps(model, spl, vi)
@@ -89,7 +89,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     p = sample_momentum(vi, spl)
 
     dprintln(3, "X -> R...")
-    if spl.alg.gid != 0 vi = link(vi, spl) end
+    if spl.alg.gid != 0 link!(vi, spl) end
 
     dprintln(2, "recording old H...")
     oldH = find_H(p, model, vi, spl)
@@ -126,7 +126,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     end
 
     dprintln(3, "R -> X...")
-    if spl.alg.gid != 0 vi = invlink(vi, spl); cleandual!(vi) end
+    if spl.alg.gid != 0 invlink!(vi, spl); cleandual!(vi) end
 
     dprintln(2, "decide wether to accept...")
     if rand() < α       # accepted

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -86,9 +86,8 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     p = sample_momentum(vi, spl)
 
     dprintln(2, "recording old values...")
-    old_θ = vi[spl]
-    old_logp = getlogp(vi)
-    old_H = find_H(p, old_logp)
+    old_θ = vi[spl]; old_logp = getlogp(vi)
+    old_H = find_H(p, model, vi, spl)
 
     τ = max(1, round(Int, λ / ϵ))
     dprintln(2, "leapfrog for $τ steps with step size $ϵ")

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -68,7 +68,7 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     vi
   else
     dprintln(2, "recording old θ...")
-    old_vi = deepcopy(vi)
+    old_θ = vi[spl]
 
     # Set parameters
     δ = spl.alg.delta
@@ -127,7 +127,8 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
       push!(spl.info[:accept_his], true)
     else                # rejected
       push!(spl.info[:accept_his], false)
-      vi = old_vi
+      vi[spl] = old_θ
+      setlogp!(vi, zero(Real))
     end
     vi
   end

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -90,8 +90,8 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     old_logp = getlogp(vi)
     old_H = find_H(p, old_logp)
 
-    dprintln(2, "leapfrog for $τ steps with step size $ϵ")
     τ = max(1, round(Int, λ / ϵ))
+    dprintln(2, "leapfrog for $τ steps with step size $ϵ")
     θ, p, τ_valid = leapfrog2(old_θ, p, τ, ϵ, model, vi, spl)
 
     dprintln(2, "computing new H...")
@@ -99,7 +99,6 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
 
     dprintln(2, "computing accept rate α...")
     α = min(1, exp(-(H - old_H)))
-
 
     haskey(spl.info, :progress) && ProgressMeter.update!(
                                      spl.info[:progress],
@@ -121,12 +120,12 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     end
 
     dprintln(2, "decide wether to accept...")
-    if rand() < α       # accepted
+    if rand() < α             # accepted
       push!(spl.info[:accept_his], true)
-    else                # rejected
+    else                      # rejected
       push!(spl.info[:accept_his], false)
-      vi[spl] = old_θ
-      setlogp!(vi, old_logp)
+      vi[spl] = old_θ         # reset Θ
+      setlogp!(vi, old_logp)  # reset logp
     end
 
     dprintln(3, "R -> X...")

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -90,9 +90,11 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
 
     τ = max(1, round(Int, λ / ϵ))
     dprintln(2, "leapfrog for $τ steps with step size $ϵ")
-    vi, p, τ_valid = leapfrog(vi, p, τ, ϵ, model, spl)
+    θ, p, τ_valid = leapfrog2(old_θ, p, τ, ϵ, model, vi, spl)
 
     dprintln(2, "computing new H...")
+    vi[spl] = θ
+    setlogp!(vi, zero(Real))
     H = τ_valid == 0 ? Inf : find_H(p, model, vi, spl)
 
     dprintln(2, "computing ΔH...")

--- a/src/samplers/is.jl
+++ b/src/samplers/is.jl
@@ -57,4 +57,4 @@ assume(spl::Sampler{IS}, dist::Distribution, vn::VarName, vi::VarInfo) = begin
 end
 
 observe(spl::Sampler{IS}, dist::Distribution, value::Any, vi::VarInfo) =
-  vi.logp += logpdf(dist, value)
+  acclogp!(vi, logpdf(dist, value))

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -47,14 +47,14 @@ function step(model::Function, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
     vi_0 = deepcopy(vi)
 
     dprintln(3, "X -> R...")
-    if spl.alg.gid != 0 vi = link(vi, spl) end
+    if spl.alg.gid != 0 link!(vi, spl) end
 
     # Heuristically find optimal ϵ
     # ϵ_bar, ϵ = find_good_eps(model, spl, vi)
     ϵ = find_good_eps(model, spl, vi)
 
     dprintln(3, "R -> X...")
-    if spl.alg.gid != 0 vi = invlink(vi, spl) end
+    if spl.alg.gid != 0 invlink!(vi, spl) end
 
     spl.info[:ϵ] = ϵ
     spl.info[:μ] = log(10 * ϵ)
@@ -78,7 +78,7 @@ function step(model::Function, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
     p = sample_momentum(vi, spl)
 
     dprintln(3, "X -> R...")
-    if spl.alg.gid != 0 vi = link(vi, spl) end
+    if spl.alg.gid != 0 link!(vi, spl) end
 
     dprintln(2, "recording old H...")
     H0 = find_H(p, model, vi, spl)
@@ -112,7 +112,7 @@ function step(model::Function, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
     end
 
     dprintln(3, "R -> X...")
-    if spl.alg.gid != 0 vi = invlink(vi, spl); cleandual!(vi) end
+    if spl.alg.gid != 0 invlink!(vi, spl); cleandual!(vi) end
 
     # Use Dual Averaging to adapt ϵ
     m = spl.info[:m] += 1

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -45,7 +45,7 @@ end
 function step(model::Function, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
   if is_first
     if spl.alg.gid != 0 link!(vi, spl) end      # X -> R
-    ϵ = find_good_eps(model, spl, vi)           # heuristically find optimal ϵ
+    ϵ = find_good_eps(model, vi, spl)           # heuristically find optimal ϵ
     if spl.alg.gid != 0 invlink!(vi, spl) end   # R -> X
 
     spl.info[:ϵ] = ϵ

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -44,17 +44,9 @@ end
 
 function step(model::Function, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
   if is_first
-    vi_0 = deepcopy(vi)
-
-    dprintln(3, "X -> R...")
-    if spl.alg.gid != 0 link!(vi, spl) end
-
-    # Heuristically find optimal ϵ
-    # ϵ_bar, ϵ = find_good_eps(model, spl, vi)
-    ϵ = find_good_eps(model, spl, vi)
-
-    dprintln(3, "R -> X...")
-    if spl.alg.gid != 0 invlink!(vi, spl) end
+    if spl.alg.gid != 0 link!(vi, spl) end      # X -> R
+    ϵ = find_good_eps(model, spl, vi)           # heuristically find optimal ϵ
+    if spl.alg.gid != 0 invlink!(vi, spl) end   # R -> X
 
     spl.info[:ϵ] = ϵ
     spl.info[:μ] = log(10 * ϵ)
@@ -65,7 +57,7 @@ function step(model::Function, spl::Sampler{NUTS}, vi::VarInfo, is_first::Bool)
 
     push!(spl.info[:accept_his], true)
 
-    vi_0
+    vi
   else
     # Set parameters
     δ = spl.alg.delta

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -119,8 +119,5 @@ assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::Va
   end
 end
 
-observe{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, value, vi) = begin
-  lp = logpdf(dist, value)
-  acclogp!(vi, lp)
-  produce(lp)
-end
+observe{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, value, vi) =
+  produce(logpdf(dist, value))

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -50,7 +50,7 @@ step(model::Function, spl::Sampler{PG}, vi::VarInfo, _::Bool) = step(model, spl,
 step(model::Function, spl::Sampler{PG}, vi::VarInfo) = begin
   particles = ParticleContainer{TraceR}(model)
 
-  vi.index = 0; vi.num_produce = 0;  # We need this line cause fork2 deepcopy `vi`. 
+  vi.index = 0; vi.num_produce = 0;  # We need this line cause fork2 deepcopy `vi`.
   ref_particle = isempty(vi) ?
                  nothing :
                  fork2(TraceR(model, spl, vi))
@@ -121,6 +121,6 @@ end
 
 observe{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, value, vi) = begin
   lp = logpdf(dist, value)
-  vi.logp += lp
+  acclogp!(vi, lp)
   produce(lp)
 end

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -33,7 +33,7 @@ assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo) = begin
     r = rand(dist)
     push!(vi, vn, r, dist, 0)
   end
-  vi.logp += logpdf(dist, r, istransformed(vi, vn))
+  vi.logp += logpdf(dist, r, istrans(vi, vn))
   r
 end
 

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -33,12 +33,12 @@ assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo) = begin
     r = rand(dist)
     push!(vi, vn, r, dist, 0)
   end
-  vi.logp += logpdf(dist, r, istrans(vi, vn))
+  acclogp!(vi, logpdf(dist, r, istrans(vi, vn)))
   r
 end
 
-observe(spl::Void, d::Distribution, value::Any, vi::VarInfo) = begin
-  lp = logpdf(d, value)
+observe(spl::Void, dist::Distribution, value::Any, vi::VarInfo) = begin
+  lp = logpdf(dist, value)
   vi.logw += lp
-  vi.logp += lp
+  acclogp!(vi, lp)
 end

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -42,6 +42,6 @@ observe(spl::Void, dist::Distribution, value::Any, vi::VarInfo) = begin
     println("catch you")
     exit()
   else
-    acclogp!(vi, logpdf(dist, map(x -> Dual(x), value)))
+    acclogp!(vi, logpdf(dist, value))
   end
 end

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -38,7 +38,10 @@ assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo) = begin
 end
 
 observe(spl::Void, dist::Distribution, value::Any, vi::VarInfo) = begin
-  lp = logpdf(dist, value)
-  vi.logw += lp
-  acclogp!(vi, lp)
+  if isa(dist, UnivariateDistribution) && isa(value, Vector)
+    println("catch you")
+    exit()
+  else
+    acclogp!(vi, logpdf(dist, map(x -> Dual(x), value)))
+  end
 end

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -37,12 +37,10 @@ assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo) = begin
   r
 end
 
-observe(spl::Void, dist::Distribution, value::Any, vi::VarInfo) = begin
-  if isa(dist, UnivariateDistribution) && isa(value, Vector) ||
-     isa(dist, MultivariateDistribution) && isa(value, Matrix) || # Note: each value is a column vector
-     isa(dist, MatrixDistribution) && isa(value, Array{typeof(value[1]),3})
-    acclogp!(vi, sum(logpdf(dist, value)))
-  else
-    acclogp!(vi, logpdf(dist, value))
-  end
+observe(spl::Void, dist::Distribution, value::Any, vi::VarInfo) =
+  acclogp!(vi, logpdf(dist, value))
+
+observe{T<:Distribution}(spl::Void, dists::Vector{T}, value::Any, vi::VarInfo) = begin
+  @assert length(dists) == 1 "[observe] Turing only support vectorizing i.i.d distribution"
+  acclogp!(vi, sum(logpdf(dists[1], value)))
 end

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -38,9 +38,10 @@ assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo) = begin
 end
 
 observe(spl::Void, dist::Distribution, value::Any, vi::VarInfo) = begin
-  if isa(dist, UnivariateDistribution) && isa(value, Vector)
-    println("catch you")
-    exit()
+  if isa(dist, UnivariateDistribution) && isa(value, Vector) ||
+     isa(dist, MultivariateDistribution) && isa(value, Matrix) || # Note: each value is a column vector
+     isa(dist, MatrixDistribution) && isa(value, Array{typeof(value[1]),3})
+    acclogp!(vi, sum(logpdf(dist, value)))
   else
     acclogp!(vi, logpdf(dist, value))
   end

--- a/src/samplers/support/helper.jl
+++ b/src/samplers/support/helper.jl
@@ -26,7 +26,13 @@ vectorize{T<:Real}(d::MatrixDistribution,       r::Matrix{T}) = Vector{Real}(vec
 # Note this is not the case for MultivariateDistribution so I guess this might be lack of
 # support for some types related to matrices (like PDMat).
 reconstruct(d::Distribution, val::Vector) = reconstruct(d, val, typeof(val[1]))
-reconstruct(d::UnivariateDistribution,   val::Vector, T::Type) = T(val[1])
+reconstruct(d::UnivariateDistribution,   val::Vector, T::Type) = begin
+  if length(val) == 1
+    T(val[1])
+  else
+    Vector{T}(val)
+  end
+end
 reconstruct(d::MultivariateDistribution, val::Vector, T::Type) = Vector{T}(val)
 reconstruct(d::MatrixDistribution,       val::Vector, T::Type) = Array{T, 2}(reshape(val, size(d)...))
 

--- a/src/samplers/support/helper.jl
+++ b/src/samplers/support/helper.jl
@@ -41,6 +41,6 @@ Sample(vi::VarInfo) = begin
     value[sym(vn)] = realpart(vi[vn])
   end
   # NOTE: do we need to check if lp is 0?
-  value[:lp] = realpart(vi.logp)
+  value[:lp] = realpart(getlogp(vi))
   Sample(0.0, value)
 end

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -53,9 +53,10 @@ end
 
 # Compute Hamiltonian
 find_H(p::Vector, model::Function, vi::VarInfo, spl::Sampler) = begin
-  expand!(vi)
-  # TODO: remove below by making sure that the logp is always updated
-  vi = runmodel(model, vi, spl)
+  # NOTE: getlogp(vi) = 0 means the current vals[end] hasn't been used at all.
+  #       This can be a result of link/invlink (where expand! is used)
+  if getlogp(vi) == 0 vi = runmodel(model, vi, spl) end
+
   H = dot(p, p) / 2 + realpart(-getlogp(vi))
   if isnan(H) H = Inf else H end
 end

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -47,7 +47,7 @@ leapfrog(vi::VarInfo, p::Vector, τ::Int, ϵ::Float64, model::Function, spl::Sam
 
   dprintln(3, "first gradient...")
   grad = gradient2(vi, model, spl)
-  # Verify gradients; reject if gradients is NaN or Inf.
+  verifygrad(grad) || (return vi, p, 0)
 
 
   dprintln(2, "leapfrog stepping...")

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -1,6 +1,9 @@
 global Δ_max = 1000
 
-setchunksize(chun_size::Int) = global CHUNKSIZE = chunk_size
+setchunksize(chunk_size::Int) = begin
+  println("[Turing]: AD chunk size is set as $chunk_size")
+  global CHUNKSIZE = chunk_size
+end
 
 runmodel(model::Function, vi::VarInfo, spl::Union{Void,Sampler}) = begin
   dprintln(4, "run model...")

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -6,6 +6,7 @@ runmodel(model::Function, vi::VarInfo, spl::Union{Void,Sampler}) = begin
   dprintln(4, "run model...")
   vi.index = 0
   setlogp!(vi, zero(Real))
+  if spl != nothing spl.info[:eval_num] += 1 end
   model(vi=vi, sampler=spl) # run model
 end
 
@@ -28,6 +29,7 @@ leapfrog2(θ::Vector, p::Vector, τ::Int, ϵ::Float64,
 
     p -= ϵ * grad / 2
     θ += ϵ * p  # full step for state
+    spl.info[:lf_num] += 1  # record leapfrog num
 
     vi[spl] = θ
     grad = gradient2(vi, model, spl)

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -57,6 +57,7 @@ end
 # Compute Hamiltonian
 function find_H(p::Vector, model::Function, _vi::VarInfo, spl::Sampler)
   vi = deepcopy(_vi)
+  # TODO: remove below by making sure that the logp is always updated
   vi = runmodel(model, vi, spl)
   H = dot(p, p) / 2 + realpart(-getlogp(vi))
   if isnan(H) H = Inf else H end

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -28,7 +28,9 @@ leapfrog2(θ::Vector, p::Vector, τ::Int, ϵ::Float64,
 
   τ_valid = 0
   for t in 1:τ
-    p_old = copy(p); θ_old = θ; old_logp = getlogp(vi)
+    # NOTE: we dont need copy here becase arr += another_arr
+    #       doesn't change arr in-place
+    p_old = p; θ_old = (θ); old_logp = getlogp(vi)
 
     p -= ϵ * grad / 2
     θ += ϵ * p  # full step for state
@@ -56,7 +58,7 @@ leapfrog(vi::VarInfo, p::Vector, τ::Int, ϵ::Float64, model::Function, spl::Sam
   dprintln(2, "leapfrog stepping...")
   τ_valid = 0
   for t in 1:τ        # do 'leapfrog' for each var
-    p_old = copy(p); θ_old = vi[spl]
+    p_old = p; θ_old = vi[spl]
 
     p -= ϵ * grad / 2
 

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -48,8 +48,10 @@ function leapfrog(_vi::VarInfo, _p::Vector, τ::Int, ϵ::Float64, model::Functio
     τ_valid += 1
   end
 
+  last!(vi)
+
   # Return updated θ and momentum
-  last(vi), p, τ_valid
+  vi, p, τ_valid
 end
 
 # Compute Hamiltonian

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -58,6 +58,7 @@ leapfrog(vi::VarInfo, p::Vector, τ::Int, ϵ::Float64, model::Function, spl::Sam
     p -= ϵ * grad / 2
 
     vi[spl] += ϵ * p  # full step for state
+    spl.info[:lf_num] += 1  # record leapfrog num
 
     grad = gradient2(vi, model, spl)
 
@@ -71,11 +72,6 @@ leapfrog(vi::VarInfo, p::Vector, τ::Int, ϵ::Float64, model::Function, spl::Sam
 
   # Return updated θ and momentum
   vi, p, τ_valid
-end
-
-find_H(p::Vector, logp::Real) = begin
-  H = dot(p, p) / 2 + realpart(-logp)
-  if isnan(H) H = Inf else H end
 end
 
 # Compute Hamiltonian

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -15,10 +15,7 @@ sample_momentum(vi::VarInfo, spl::Sampler) = begin
 end
 
 # Leapfrog step
-leapfrog(_vi::VarInfo, _p::Vector, τ::Int, ϵ::Float64, model::Function, spl::Sampler) = begin
-
-  vi = deepcopy(_vi)
-  p = deepcopy(_p)
+leapfrog(vi::VarInfo, p::Vector, τ::Int, ϵ::Float64, model::Function, spl::Sampler) = begin
 
   dprintln(3, "first gradient...")
   grad = gradient2(vi, model, spl)
@@ -73,14 +70,14 @@ find_good_eps{T}(model::Function, spl::Sampler{T}, vi::VarInfo) = begin
   #   vi_prime, p_prime, τ_valid = leapfrog(vi, p, 1, ϵ, model, spl)
   # end
   # ϵ_bar = ϵ
-  vi_prime, p_prime, τ = leapfrog(vi, p, 1, ϵ, model, spl)
+  vi_prime, p_prime, τ = leapfrog(deepcopy(vi), deepcopy(p), 1, ϵ, model, spl)
   log_p_r_Θ′ = τ == 0 ? -Inf : -find_H(p_prime, model, vi_prime, spl)   # calculate new p(Θ, p)
 
   # Heuristically find optimal ϵ
   a = 2.0 * (log_p_r_Θ′ - log_p_r_Θ > log(0.5) ? 1 : 0) - 1
   while (exp(log_p_r_Θ′ - log_p_r_Θ))^a > 2.0^(-a)
     ϵ = 2.0^a * ϵ
-    vi_prime, p_prime, τ = leapfrog(vi, p, 1, ϵ, model, spl)
+    vi_prime, p_prime, τ = leapfrog(deepcopy(vi), deepcopy(p), 1, ϵ, model, spl)
     log_p_r_Θ′ = τ == 0 ? -Inf : -find_H(p_prime, model, vi_prime, spl)
     dprintln(1, "a = $a, log_p_r_Θ′ = $log_p_r_Θ′")
   end

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -5,6 +5,7 @@ setchunksize(chun_size::Int) = global CHUNKSIZE = chunk_size
 runmodel(model::Function, vi::VarInfo, spl::Union{Void,Sampler}) = begin
   dprintln(4, "run model...")
   vi.index = 0
+  setlogp!(vi, zero(Real))
   model(vi=vi, sampler=spl) # run model
 end
 

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -2,22 +2,19 @@ global Δ_max = 1000
 
 setchunksize(chun_size::Int) = global CHUNKSIZE = chunk_size
 
-function runmodel(model::Function, vi::VarInfo, spl::Union{Void,Sampler})
+runmodel(model::Function, vi::VarInfo, spl::Union{Void,Sampler}) = begin
   dprintln(4, "run model...")
-  expand!(vi)
   vi.index = 0
-  vi = model(vi=vi, sampler=spl) # run model
-  last!(vi)
-  vi
+  model(vi=vi, sampler=spl) # run model
 end
 
-function sample_momentum(vi::VarInfo, spl::Sampler)
+sample_momentum(vi::VarInfo, spl::Sampler) = begin
   dprintln(2, "sampling momentum...")
   randn(length(getranges(vi, spl)))
 end
 
 # Leapfrog step
-function leapfrog(_vi::VarInfo, _p::Vector, τ::Int, ϵ::Float64, model::Function, spl::Sampler)
+leapfrog(_vi::VarInfo, _p::Vector, τ::Int, ϵ::Float64, model::Function, spl::Sampler) = begin
 
   vi = deepcopy(_vi)
   p = deepcopy(_p)
@@ -55,15 +52,15 @@ function leapfrog(_vi::VarInfo, _p::Vector, τ::Int, ϵ::Float64, model::Functio
 end
 
 # Compute Hamiltonian
-function find_H(p::Vector, model::Function, _vi::VarInfo, spl::Sampler)
-  vi = deepcopy(_vi)
+find_H(p::Vector, model::Function, vi::VarInfo, spl::Sampler) = begin
+  expand!(vi)
   # TODO: remove below by making sure that the logp is always updated
   vi = runmodel(model, vi, spl)
   H = dot(p, p) / 2 + realpart(-getlogp(vi))
   if isnan(H) H = Inf else H end
 end
 
-function find_good_eps{T}(model::Function, spl::Sampler{T}, vi::VarInfo)
+find_good_eps{T}(model::Function, spl::Sampler{T}, vi::VarInfo) = begin
   ϵ, p = 1.0, sample_momentum(vi, spl)    # set initial epsilon and momentums
   log_p_r_Θ = -find_H(p, model, vi, spl)  # calculate p(Θ, r) = exp(-H(Θ, r))
 

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -29,27 +29,23 @@ leapfrog(vi::VarInfo, p::Vector, τ::Int, ϵ::Float64, model::Function, spl::Sam
   verifygrad(grad) || (return vi, p, 0)
 
   dprintln(2, "leapfrog stepping...")
-  τ_valid = 0; p_old = copy(p)
+  τ_valid = 0;
   for t in 1:τ        # do 'leapfrog' for each var
-    p_old[1:end] = p[1:end]
+    p_old = copy(p); θ_old = vi[spl]
 
     p -= ϵ * grad / 2
-
-    expand!(vi)
 
     vi[spl] += ϵ * p  # full step for state
 
     grad = gradient2(vi, model, spl)
 
     # Verify gradients; reject if gradients is NaN or Inf
-    verifygrad(grad) || (shrink!(vi); p = p_old; break)
+    verifygrad(grad) || (vi[spl] = θ_old; p = p_old; break)
 
     p -= ϵ * grad / 2
 
     τ_valid += 1
   end
-
-  last!(vi)
 
   # Return updated θ and momentum
   vi, p, τ_valid

--- a/test/compiler.jl/noreturn.jl
+++ b/test/compiler.jl/noreturn.jl
@@ -1,3 +1,4 @@
+include("../utility.jl")
 using Distributions
 using Turing
 using Base.Test

--- a/test/nuts.jl/nuts.jl
+++ b/test/nuts.jl/nuts.jl
@@ -13,3 +13,9 @@ alg = NUTS(2500, 500, 0.65)
 res = sample(gdemo([1.5, 2.0]), alg)
 
 check_numerical(res, [:s, :m], [49/24, 7/6])
+
+
+alg = Gibbs(2500, PG(50, 1, :s), NUTS(500, 0.65, :m))
+res = sample(gdemo([1.5, 2.0]), alg)
+
+check_numerical(res, [:s, :m], [49/24, 7/6])

--- a/test/nuts.jl/nuts.jl
+++ b/test/nuts.jl/nuts.jl
@@ -1,3 +1,4 @@
+include("../utility.jl")
 using Distributions, Turing
 
 @model gdemo(x) = begin

--- a/test/nuts.jl/nuts.jl
+++ b/test/nuts.jl/nuts.jl
@@ -8,7 +8,7 @@ using Distributions, Turing
   return s, m
 end
 
-alg = NUTS(1000, 200, 0.65)
+alg = NUTS(2500, 500, 0.65)
 res = sample(gdemo([1.5, 2.0]), alg)
 
 check_numerical(res, [:s, :m], [49/24, 7/6])

--- a/test/nuts.jl/nuts.jl
+++ b/test/nuts.jl/nuts.jl
@@ -1,4 +1,3 @@
-include("../utility.jl")
 using Distributions, Turing
 
 @model gdemo(x) = begin

--- a/test/nuts_nb.jl
+++ b/test/nuts_nb.jl
@@ -1,18 +1,48 @@
-using Distributions
-using Turing
-using Stan
+# using Distributions
+# using Turing
+# using Stan
+#
+# include(Pkg.dir("Turing")*"/benchmarks/benchmarkhelper.jl")
+# include(Pkg.dir("Turing")*"/example-models/stan-models/MoC-stan.data.jl")
+#
+# @model nbmodel(K, V, M, N, z, w, doc, alpha, beta) = begin
+#   theta ~ Dirichlet(alpha)
+#   phi = Array{Any}(K)
+#   for k = 1:K
+#     phi[k] ~ Dirichlet(beta)
+#   end
+#   for m = 1:M
+#     z[m] ~ Categorical(theta)
+#   end
+#   for n = 1:N
+#     w[n] ~ Categorical(phi[z[doc[n]]])
+#   end
+#   phi
+# end
+#
+#
+# bench_res = tbenchmark("NUTS(1000, 0.65)", "nbmodel", "data=nbstandata[1]")
+# bench_res[4].names = ["phi[1]", "phi[2]", "phi[3]", "phi[4]"]
+# logd = build_logd("Naive Bayes", bench_res...)
+#
+# include(Pkg.dir("Turing")*"/benchmarks/"*"MoC-stan.run.jl")
+# logd["stan"] = stan_d
+# logd["time_stan"] = nb_time
+#
+# print_log(logd)
 
-include(Pkg.dir("Turing")*"/benchmarks/benchmarkhelper.jl")
 
-include(Pkg.dir("Turing")*"/benchmarks/naive.bayes-stan.data.jl")
-include(Pkg.dir("Turing")*"/benchmarks/naive.bayes.model.jl")
+include("utility.jl")
+using Distributions, Turing
 
-bench_res = tbenchmark("NUTS(1000, 0.65)", "nbmodel", "data=nbstandata[1]")
-bench_res[4].names = ["phi[1]", "phi[2]", "phi[3]", "phi[4]"]
-logd = build_logd("Naive Bayes", bench_res...)
+@model gdemo(x) = begin
+  s ~ InverseGamma(2,3)
+  m ~ Normal(0,sqrt(s))
+    x ~ Normal(m, sqrt(s))
+  return s, m
+end
 
-include(Pkg.dir("Turing")*"/benchmarks/naive.bayes-stan.run.jl")
-logd["stan"] = stan_d
-logd["time_stan"] = nb_time
+alg = NUTS(2500, 500, 0.65)
+res = sample(gdemo([1.5, 2.0]), alg)
 
-print_log(logd)
+check_numerical(res, [:s, :m], [49/24, 7/6])

--- a/test/quick.jl
+++ b/test/quick.jl
@@ -1,0 +1,34 @@
+using Distributions
+using Turing
+using Stan
+
+include(Pkg.dir("Turing")*"/benchmarks/benchmarkhelper.jl")
+include(Pkg.dir("Turing")*"/example-models/stan-models/MoC-stan.data.jl")
+
+@model nbmodel(K, V, M, N, z, w, doc, alpha, beta) = begin
+  theta ~ Dirichlet(alpha)
+  phi = Array{Any}(K)
+  for k = 1:K
+    phi[k] ~ Dirichlet(beta)
+  end
+  for m = 1:M
+    z[m] ~ Categorical(theta)
+  end
+  for n = 1:N
+    w[n] ~ Categorical(phi[z[doc[n]]])
+  end
+  phi
+end
+
+
+# bench_res = tbenchmark("NUTS(1000, 0.65)", "nbmodel", "data=nbstandata[1]")
+# bench_res[4].names = ["phi[1]", "phi[2]", "phi[3]", "phi[4]"]
+# logd = build_logd("Naive Bayes", bench_res...)
+#
+# include(Pkg.dir("Turing")*"/benchmarks/"*"MoC-stan.run.jl")
+# logd["stan"] = stan_d
+# logd["time_stan"] = nb_time
+#
+# print_log(logd)
+
+samples = sample(nbmodel(data=nbstandata[1]), NUTS(1000, 0.65))

--- a/test/quick.jl
+++ b/test/quick.jl
@@ -11,12 +11,16 @@ include(Pkg.dir("Turing")*"/example-models/stan-models/MoC-stan.data.jl")
   for k = 1:K
     phi[k] ~ Dirichlet(beta)
   end
-  for m = 1:M
-    z[m] ~ Categorical(theta)
-  end
+
+  log_theta = log(theta)
+  Turing.acclogp!(vi, sum(log_theta[z[1:M]]))
+
+  log_phi = map(x->log(x), phi)
   for n = 1:N
-    w[n] ~ Categorical(phi[z[doc[n]]])
+  #  w[n] ~ Categorical(phi[z[doc[n]]])
+    Turing.acclogp!(vi, log_phi[z[doc[n]]][w[n]])
   end
+
   phi
 end
 
@@ -31,4 +35,4 @@ end
 #
 # print_log(logd)
 
-samples = sample(nbmodel(data=nbstandata[1]), NUTS(1000, 0.65))
+samples = sample(nbmodel(data=nbstandata[1]), HMC(1000, 0.1, 4))

--- a/test/quick.jl
+++ b/test/quick.jl
@@ -7,10 +7,8 @@ include(Pkg.dir("Turing")*"/example-models/stan-models/MoC-stan.data.jl")
 
 @model nbmodel(K, V, M, N, z, w, doc, alpha, beta) = begin
   theta ~ Dirichlet(alpha)
-  phi = Array{Any}(K)
-  for k = 1:K
-    phi[k] ~ Dirichlet(beta)
-  end
+  phi = Vector{Vector{Real}}(K)
+  phi ~ [Dirichlet(beta)]
 
   log_theta = log(theta)
   Turing.acclogp!(vi, sum(log_theta[z[1:M]]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ testcases = Dict(
 #     samplers/
 #       support/
           "resample.jl" => ["resample", "particlecontainer",],
+        "sampler.jl" => ["vectorize_observe",],
         "gibbs.jl" => ["gibbs", "gibbs2", "gibbs_constructor",],
         "nuts.jl"  => ["nuts_cons", "nuts",
                       #  "nuts_geweke",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ testcases = Dict(
 #     samplers/
 #       support/
           "resample.jl" => ["resample", "particlecontainer",],
-        "sampler.jl" => ["vectorize_observe",],
+        "sampler.jl" => ["vectorize_observe", "vec_assume",],
         "gibbs.jl" => ["gibbs", "gibbs2", "gibbs_constructor",],
         "nuts.jl"  => ["nuts_cons", "nuts",
                       #  "nuts_geweke",

--- a/test/sampler.jl/vec_assume.jl
+++ b/test/sampler.jl/vec_assume.jl
@@ -6,10 +6,10 @@ setchunksize(100)
 # Test for vectorize UnivariateDistribution
 @model vdemo() = begin
   x = Vector{Real}(100)
-  # x ~ [Normal(0, sqrt(4))]
-  for i = 1:100
-    x[i] ~ Normal(0, sqrt(4))
-  end
+  x ~ [Normal(0, sqrt(4))]
+  # for i = 1:100
+  #   x[i] ~ Normal(0, sqrt(4))
+  # end
 end
 
 alg = HMC(1000, 0.2, 4)

--- a/test/sampler.jl/vec_assume.jl
+++ b/test/sampler.jl/vec_assume.jl
@@ -1,0 +1,17 @@
+include("../utility.jl")
+using Distributions, Turing
+
+
+setchunksize(100)
+# Test for vectorize UnivariateDistribution
+@model vdemo() = begin
+  x = Vector{Real}(100)
+  # x ~ [Normal(0, sqrt(4))]
+  for i = 1:100
+    x[i] ~ Normal(0, sqrt(4))
+  end
+end
+
+alg = HMC(1000, 0.2, 4)
+res = sample(vdemo(), alg)
+println(mean(mean(res[:x])))

--- a/test/sampler.jl/vec_assume.jl
+++ b/test/sampler.jl/vec_assume.jl
@@ -1,17 +1,39 @@
 include("../utility.jl")
-using Distributions, Turing
+using Distributions, Turing, Base.Test
 
+N = 100
+setchunksize(N)
+alg = HMC(1000, 0.2, 4)
 
-setchunksize(100)
-# Test for vectorize UnivariateDistribution
 @model vdemo() = begin
-  x = Vector{Real}(100)
-  x ~ [Normal(0, sqrt(4))]
-  # for i = 1:100
-  #   x[i] ~ Normal(0, sqrt(4))
-  # end
+  x = Vector{Real}(N)
+  for i = 1:N
+    x[i] ~ Normal(0, sqrt(4))
+  end
 end
 
-alg = HMC(1000, 0.2, 4)
-res = sample(vdemo(), alg)
-println(mean(mean(res[:x])))
+t_loop = @elapsed res = sample(vdemo(), alg)
+@test_approx_eq_eps mean(mean(res[:x])) 0 0.1
+
+
+# Test for vectorize UnivariateDistribution
+@model vdemo() = begin
+  x = Vector{Real}(N)
+  x ~ [Normal(0, 2)]
+end
+
+t_vec = @elapsed res = sample(vdemo(), alg)
+@test_approx_eq_eps mean(mean(res[:x])) 0 0.1
+
+
+@model vdemo() = begin
+  x ~ MvNormal(zeros(N), 2 * ones(N))
+end
+
+t_mv = @elapsed res = sample(vdemo(), alg)
+@test_approx_eq_eps mean(mean(res[:x])) 0 0.1
+
+println("Time for")
+println("  Loop : $t_loop")
+println("  Vec  : $t_vec")
+println("  Mv   : $t_mv")

--- a/test/sampler.jl/vec_assume_mv.jl
+++ b/test/sampler.jl/vec_assume_mv.jl
@@ -1,0 +1,34 @@
+include("../utility.jl")
+using Distributions, Turing, Base.Test
+
+N = 5
+beta = [0.5, 0.5]
+setchunksize(N*length(beta))
+alg = HMC(1000, 0.2, 4)
+
+# Test for vectorize UnivariateDistribution
+@model vdemo() = begin
+  phi = Vector{Vector{Real}}(N)
+  phi ~ [Dirichlet(beta)]
+end
+
+t_vec = @elapsed res = sample(vdemo(), alg)
+
+
+
+
+@model vdemo() = begin
+  phi = Vector{Vector{Real}}(N)
+  for i = 1:N
+    phi[i] ~ Dirichlet(beta)
+  end
+end
+
+t_loop = @elapsed res = sample(vdemo(), alg)
+
+
+
+
+println("Time for")
+println("  Loop : $t_loop")
+println("  Vec  : $t_vec")

--- a/test/sampler.jl/vectorize_observe.jl
+++ b/test/sampler.jl/vectorize_observe.jl
@@ -32,17 +32,34 @@
 # print_log(logd)
 
 
-include("utility.jl")
 using Distributions, Turing
 
-@model gdemo(x) = begin
+# Test for vectorize UnivariateDistribution
+@model vdemo(x) = begin
   s ~ InverseGamma(2,3)
   m ~ Normal(0,sqrt(s))
-    x ~ Normal(m, sqrt(s))
+  x ~ Normal(m, sqrt(s))
+  # for i = 1:length(x)
+  #   x[i] ~ Normal(m, sqrt(s))
+  # end
   return s, m
 end
 
 alg = NUTS(2500, 500, 0.65)
-res = sample(gdemo([1.5, 2.0]), alg)
+x = randn(1000)
+res = sample(vdemo(x), alg)
 
-check_numerical(res, [:s, :m], [49/24, 7/6])
+check_numerical(res, [:s, :m], [1, sum(x) / (1 + length(x))])
+
+# Test for vectorize MultivariateDistribution
+
+D = 2
+@model vdemo2(x) = begin
+  μ ~ MvNormal(zeros(D), ones(D))
+  x ~ MvNormal(μ, ones(D))
+end
+
+alg = NUTS(2500, 500, 0.65)
+res = sample(vdemo2(randn(D,1000)), alg)
+
+# TODO: Test for vectorize MatrixDistribution

--- a/test/sampler.jl/vectorize_observe.jl
+++ b/test/sampler.jl/vectorize_observe.jl
@@ -31,14 +31,14 @@
 #
 # print_log(logd)
 
-
+include("../utility.jl")
 using Distributions, Turing
 
 # Test for vectorize UnivariateDistribution
 @model vdemo(x) = begin
   s ~ InverseGamma(2,3)
   m ~ Normal(0,sqrt(s))
-  x ~ Normal(m, sqrt(s))
+  x ~ [Normal(m, sqrt(s))]
   # for i = 1:length(x)
   #   x[i] ~ Normal(m, sqrt(s))
   # end
@@ -56,7 +56,7 @@ check_numerical(res, [:s, :m], [1, sum(x) / (1 + length(x))])
 D = 2
 @model vdemo2(x) = begin
   μ ~ MvNormal(zeros(D), ones(D))
-  x ~ MvNormal(μ, ones(D))
+  x ~ [MvNormal(μ, ones(D))]
 end
 
 alg = NUTS(2500, 500, 0.65)

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -13,7 +13,7 @@ randr(vi::VarInfo, vn::VarName, dist::Distribution, count::Bool) = begin
   else
     if count checkindex(vn, vi) end
     r = vi[vn]
-    vi.logp += logpdf(dist, r, istransformed(vi, vn))
+    vi.logp += logpdf(dist, r, istrans(vi, vn))
     r
   end
 end

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -2,7 +2,7 @@
 # TODO: can we somehow update the tests so that we can remove these two functions below?
 
 using Turing
-using Turing: checkindex, setval!, updategid!, vectorize, CACHERESET, VarInfo, VarName, Sampler
+using Turing: checkindex, setval!, updategid!, acclogp!, vectorize, CACHERESET, VarInfo, VarName, Sampler
 
 randr(vi::VarInfo, vn::VarName, dist::Distribution, count::Bool) = begin
   vi.index = count ? vi.index + 1 : vi.index
@@ -13,7 +13,7 @@ randr(vi::VarInfo, vn::VarName, dist::Distribution, count::Bool) = begin
   else
     if count checkindex(vn, vi) end
     r = vi[vn]
-    vi.logp += logpdf(dist, r, istrans(vi, vn))
+    acclogp!(vi, logpdf(dist, r, istrans(vi, vn)))
     r
   end
 end


### PR DESCRIPTION
Address https://github.com/yebai/Turing.jl/issues/237

Also fix https://github.com/yebai/Turing.jl/issues/245

Almost done. But I also want to implement a cache of gradient  - we can actually cache some of the gradient for leapfrog. The gradient used in NUTS is especially low-efficient because our leapfrog also re-compute grad in the beginning and the recursion of NUTS calls the leapfrog by only 1 step each time:
  - The way our trick to cache gradient **inside** leapfrog makes the number of computing gradient to be t+1
  - Calling leapfrog only one-step each time means the number to be 1 + 1, and calling t times 1-step leapfrog means 2t

I think it's fine to just cache the gradient by a dictionary inside spl.info?