### PR TITLE
Control progress verbosity

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -7,6 +7,16 @@ module Turing
 global const NULL = NaN     # constant for "delete" vals
 
 global CHUNKSIZE = 50       # default chunksize used by AD
+setchunksize(chunk_size::Int) = begin
+  println("[Turing]: AD chunk size is set as $chunk_size")
+  global CHUNKSIZE = chunk_size
+end
+
+global PROGRESS = true
+turnprogress(switch::Bool) = begin
+  println("[Turing]: global PROGRESS is set as $switch")
+  global PROGRESS = switch
+end
 
 global VERBOSITY = 1        # verbosity for dprintln & dwarn
 global const FCOMPILER = 0  # verbose printing flag for compiler
@@ -64,10 +74,10 @@ import Mamba: AbstractChains, Chains
 ###########
 
 # Turing essentials - modelling macros and inference algorithms
-export @model, @~                           # modelling
-export HMC, HMCDA, NUTS, IS, SMC, PG, Gibbs # sampling algorithms
-export sample, setchunksize, resume         # inference
-export dprintln, set_verbosity              # debugging
+export @model, @~                            # modelling
+export HMC, HMCDA, NUTS, IS, SMC, PG, Gibbs  # sampling algorithms
+export sample, setchunksize, resume          # inference
+export dprintln, set_verbosity, turnprogress # debugging
 
 # Turing-safe data structures and associated functions
 export TArray, tzeros, localcopy, IArray

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -106,7 +106,7 @@ function sample{T<:Hamiltonian}(model::Function, alg::T;
   end
 
   # HMC steps
-  spl.info[:progress] = ProgressMeter.Progress(n, 1, "[$alg_str] Sampling...", 0)
+  if PROGRESS spl.info[:progress] = ProgressMeter.Progress(n, 1, "[$alg_str] Sampling...", 0) end
   for i = 1:n
     dprintln(2, "$alg_str stepping...")
 
@@ -119,7 +119,7 @@ function sample{T<:Hamiltonian}(model::Function, alg::T;
       samples[i] = samples[i - 1]
     end
     samples[i].value[:elapsed] = time_elapsed
-    ProgressMeter.next!(spl.info[:progress])
+    if PROGRESS ProgressMeter.next!(spl.info[:progress]) end
   end
 
   println("[$alg_str] Finished with")

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -98,13 +98,15 @@ function step(model, spl::Sampler{HMCDA}, vi::VarInfo, is_first::Bool)
     dprintln(2, "computing accept rate α...")
     α = min(1, exp(-(H - old_H)))
 
-    if ~(isdefined(Main, :IJulia) && Main.IJulia.inited) # Fix for Jupyter notebook.
-    stds_str = string(spl.info[:wum][:stds])
-    stds_str = length(stds_str) >= 32 ? stds_str[1:30]*"..." : stds_str
-    haskey(spl.info, :progress) && ProgressMeter.update!(
-                                     spl.info[:progress],
-                                     spl.info[:progress].counter; showvalues = [(:ϵ, ϵ), (:α, α), (:pre_cond, stds_str)]
-                                   )
+    if PROGRESS
+      if ~(isdefined(Main, :IJulia) && Main.IJulia.inited) # Fix for Jupyter notebook.
+      stds_str = string(spl.info[:wum][:stds])
+      stds_str = length(stds_str) >= 32 ? stds_str[1:30]*"..." : stds_str
+      haskey(spl.info, :progress) && ProgressMeter.update!(
+                                       spl.info[:progress],
+                                       spl.info[:progress].counter; showvalues = [(:ϵ, ϵ), (:α, α), (:pre_cond, stds_str)]
+                                     )
+      end
     end
 
     dprintln(2, "decide wether to accept...")

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -106,11 +106,16 @@ sample(model::Function, alg::PG;
        VarInfo() :
        resume_from.info[:vi]
 
-  @showprogress 1 "[PG] Sampling..." for i = 1:n
+  pm = nothing
+  if PROGRESS pm = ProgressMeter.Progress(n, 1, "[PG] Sampling...", 0) end
+
+  for i = 1:n
     time_elapsed = @elapsed vi = step(model, spl, vi)
     push!(samples, Sample(vi))
     samples[i].value[:elapsed] = time_elapsed
     time_total += time_elapsed
+
+    if PROGRESS ProgressMeter.next!(pm) end
   end
 
   println("[PG] Finished with")

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -1,10 +1,5 @@
 global Δ_max = 1000
 
-setchunksize(chunk_size::Int) = begin
-  println("[Turing]: AD chunk size is set as $chunk_size")
-  global CHUNKSIZE = chunk_size
-end
-
 runmodel(model::Function, vi::VarInfo, spl::Union{Void,Sampler}) = begin
   dprintln(4, "run model...")
   vi.index = 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@
 # Master file for running all test cases #
 ##########################################
 
+using Turing; turnprogress(false)
+
 println("[runtests.jl] runtests.jl loaded")
 
 # NOTE: please keep this test list structured when adding new test cases


### PR DESCRIPTION
Add a flag to turn on/off the progress; the IO is obvious during benchmark against Stan so I think we need an easy way to turn it off & on.