### PR TITLE
Support of Stan interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
 notifications:
     email: false
 script:
-  - if [ "$(uname)" != "Darwin" ]; then ln -s `which gcc-5` gcc && export PATH=`pwd`:$PATH && echo $PATH; fi
+  - if [ "$(uname)" != "Darwin" ]; then ln -s `which gcc-5` gcc && export PATH=`pwd`:$PATH && echo $PATH; sudo apt-get install hdf5-tools; fi
   - gcc -v
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.update();

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ script:
   - gcc -v
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.update();
-             Pkg.add("Stan");
              Pkg.clone(pwd(), "Turing");
              Pkg.build("Turing");
              if ENV["GROUP"] == "Test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
- sudo: false
+group: deprecated-2017Q3
 addons:
     apt:
         sources:
@@ -12,7 +12,6 @@ julia:
 os:
   - linux
   - osx
-group: deprecated-2017Q3
 env:
   - GROUP=Test
   - GROUP=Bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+ sudo: false
 addons:
     apt:
         sources:
@@ -48,9 +48,9 @@ script:
   - gcc -v
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.update();
+             Pkg.add("Stan");
              Pkg.clone(pwd(), "Turing");
              Pkg.build("Turing");
-             Pkg.add("Stan");
              if ENV["GROUP"] == "Test"
                 Pkg.test("Turing"; coverage=true)
              elseif ENV["GROUP"] == "Bench"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ julia:
 os:
   - linux
   - osx
+group: deprecated-2017Q3
 env:
   - GROUP=Test
   - GROUP=Bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
   - julia --check-bounds=yes -e 'Pkg.update();
              Pkg.clone(pwd(), "Turing");
              Pkg.build("Turing");
+             Pkg.add("Stan");
              if ENV["GROUP"] == "Test"
                 Pkg.test("Turing"; coverage=true)
              elseif ENV["GROUP"] == "Bench"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,8 @@
 julia 0.5
 
+Stan
 Distributions 0.11.0
 ForwardDiff
 Mamba
-Stan
 
 ProgressMeter

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,6 @@ julia 0.5
 Distributions 0.11.0
 ForwardDiff
 Mamba
+Stan
+
 ProgressMeter

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -11,7 +11,7 @@ module Turing
 using Distributions
 using ForwardDiff
 using ProgressMeter
-using Stan
+using Stan: Adapt, Hmc
 
 import Base: ~, convert, promote_rule, string, isequal, ==, hash, getindex, setindex!, push!, rand, show, isnan, isempty
 import Distributions: sample

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -11,6 +11,7 @@ module Turing
 using Distributions
 using ForwardDiff
 using ProgressMeter
+using Stan
 
 import Base: ~, convert, promote_rule, string, isequal, ==, hash, getindex, setindex!, push!, rand, show, isnan, isempty
 import Distributions: sample

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -11,12 +11,13 @@ module Turing
 using Distributions
 using ForwardDiff
 using ProgressMeter
-using Stan: Adapt, Hmc
+using Stan
 
 import Base: ~, convert, promote_rule, string, isequal, ==, hash, getindex, setindex!, push!, rand, show, isnan, isempty
 import Distributions: sample
 import ForwardDiff: gradient
 import Mamba: AbstractChains, Chains
+import Stan: Adapt, Hmc
 
 ##############################
 # Global variables/constants #

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -8,6 +8,7 @@ end
 include("support/hmc_core.jl")
 include("support/adapt.jl")
 include("support/init.jl")
+include("support/stan-interface.jl")
 include("hmcda.jl")
 include("nuts.jl")
 include("sghmc.jl")

--- a/src/samplers/support/adapt.jl
+++ b/src/samplers/support/adapt.jl
@@ -1,3 +1,5 @@
+# Acknowledgement: this adaption settings is mimicing Stan's 3-phase adaptation.
+
 type WarmUpManager
   iter_n    ::    Int
   state     ::    Int
@@ -32,6 +34,13 @@ init_warm_up_params{T<:Hamiltonian}(vi::VarInfo, spl::Sampler{T}) = begin
   wum[:γ] = adapt_conf.gamma
   wum[:t_0] = adapt_conf.t0
   wum[:κ] = adapt_conf.kappa
+
+  # Three phases settings
+  wum[:adapt_total] = spl.alg.n_adapt
+  wum[:fast_start] = adapt_conf.init_buffer
+  wum[:fast_end] = wum[:adapt_total] - adapt_conf.term_buffer
+  wum[:slow_window_size] = adapt_conf.window
+  wum[:slow_window_counter] = 0
 
   spl.info[:wum] = wum
 end
@@ -84,29 +93,29 @@ update_pre_cond(wum::WarmUpManager, θ_new) = begin
                           (2.4^2 / D) / t * (t * θ_mean_old .* θ_mean_old - (t + 1) * θ_mean_new .* θ_mean_new + θ_new .* θ_new)
     end
 
-    if t > 100
+    if (t - wum[:fast_start]) % (wum[:slow_window_size] * 2^wum[:slow_window_counter]) == 0
       wum[:stds] = sqrt(wum[:vars])
       # wum[:stds] = wum[:stds] / min(wum[:stds]...)  # old
       wum[:stds] = wum[:stds] / mean([wum[:stds]...])
+      wum[:slow_window_counter] += 1
     end
   end
 end
 
 update_state(wum::WarmUpManager) = begin
-  # TODO: make use of Stan.Adapt.init_buffer, Stan.Adapt.term_buffer and Stan.Adapt.window
   wum.iter_n += 1   # update iteration number
 
   # Update state
   if wum.state == 1
-    if wum.iter_n > 100
+    if wum.iter_n > wum[:fast_start]
       wum.state = 2
     end
   elseif wum.state == 2
-    if wum.iter_n > 900
+    if wum.iter_n > wum[:fast_end]
       wum.state = 3
     end
   elseif wum.state == 3
-    if wum.iter_n > 1000
+    if wum.iter_n > wum[:adapt_total]
       wum.state = 4
     end
   elseif wum.state == 4

--- a/src/samplers/support/adapt.jl
+++ b/src/samplers/support/adapt.jl
@@ -27,6 +27,12 @@ init_warm_up_params{T<:Hamiltonian}(vi::VarInfo, spl::Sampler{T}) = begin
   wum[:n_adapt] = spl.alg.n_adapt
   wum[:δ] = spl.alg.delta
 
+  # Stan.Adapt
+  adapt_conf = spl.info[:adapt_conf]
+  wum[:γ] = adapt_conf.gamma
+  wum[:t_0] = adapt_conf.t0
+  wum[:κ] = adapt_conf.kappa
+
   spl.info[:wum] = wum
 end
 
@@ -39,7 +45,7 @@ adapt_step_size(wum::WarmUpManager, stats::Float64) = begin
   dprintln(2, "adapting step size ϵ...")
   m = wum[:m] += 1
   if m <= wum[:n_adapt]
-    γ = 0.05; t_0 = 10; κ = 0.75; δ = wum[:δ]
+    γ = wum[:γ]; t_0 = wum[:t_0]; κ = wum[:κ]; δ = wum[:δ]
     μ = wum[:μ]; ϵ_bar = wum[:ϵ_bar]; H_bar = wum[:H_bar]
 
     H_bar = (1 - 1 / (m + t_0)) * H_bar + 1 / (m + t_0) * (δ - stats)

--- a/src/samplers/support/adapt.jl
+++ b/src/samplers/support/adapt.jl
@@ -93,6 +93,7 @@ update_pre_cond(wum::WarmUpManager, θ_new) = begin
 end
 
 update_state(wum::WarmUpManager) = begin
+  # TODO: make use of Stan.Adapt.init_buffer, Stan.Adapt.term_buffer and Stan.Adapt.window
   wum.iter_n += 1   # update iteration number
 
   # Update state

--- a/src/samplers/support/stan-interface.jl
+++ b/src/samplers/support/stan-interface.jl
@@ -20,15 +20,15 @@ sample{T<:Function}(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool,
   if adapt.engaged == false
     if isa(alg.engine, Stan.Static)   # hmc
       stepnum = Int(round(alg.engine.int_time / alg.stepsize))
-      sample(mf, HMC(num_samples, alg.stepsize, stepnum))
+      sample(mf, HMC(num_samples, alg.stepsize, stepnum); adapt_conf=adapt)
     elseif isa(alg.engine, Stan.Nuts) # error
       error("[Turing.sample] Stan.Nuts cannot be used with adapt.engaged set as false")
     end
   else
     if isa(alg.engine, Stan.Static)   # hmcda
-      sample(mf, HMCDA(num_samples, num_warmup, adapt.delta, alg.engine.int_time))
+      sample(mf, HMCDA(num_samples, num_warmup, adapt.delta, alg.engine.int_time); adapt_conf=adapt)
     elseif isa(alg.engine, Stan.Nuts) # nuts
-      sample(mf, NUTS(num_samples, num_warmup, adapt.delta))
+      sample(mf, NUTS(num_samples, num_warmup, adapt.delta); adapt_conf=adapt)
     end
   end
 end

--- a/src/samplers/support/stan-interface.jl
+++ b/src/samplers/support/stan-interface.jl
@@ -1,0 +1,34 @@
+# NOTE:
+#   Type fields
+#     fieldnames(Stan.Sample)
+#       num_samples, num_warmup, save_warmup, thin, adapt, algorithm
+
+#     fieldnames(Stan.Hmc)
+#       engine, metric, stepsize, stepsize_jitter
+
+#     fieldnames(Stan.Adapt)
+#       engaged, gamma, delta, kappa, t0, init_buffer, term_buffer, window
+
+#   Ref
+#     http://goedman.github.io/Stan.jl/latest/index.html#Types-1
+
+sample{T<:Function}(mf::T, ss::Stan.Sample) = sample(mf, ss.num_samples, ss.num_warmup, ss.save_warmup, ss.thin, ss.adapt, ss.alg)
+sample{T<:Function}(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool, thin::Int, ss::Stan.Sample) =
+  sample(mf, num_samples, num_warmup, save_warmup, thin, ss.adapt, ss.alg)
+
+sample{T<:Function}(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool, thin::Int, adapt::Stan.Adapt, alg::Stan.Hmc) = begin
+  if adapt.engaged == false
+    if isa(alg.engine, Stan.Static)   # hmc
+      stepnum = Int(round(alg.engine.int_time / alg.stepsize))
+      sample(mf, HMC(num_samples, alg.stepsize, stepnum))
+    elseif isa(alg.engine, Stan.Nuts) # error
+      error("[Turing.sample] Stan.Nuts cannot be used with adapt.engaged set as false")
+    end
+  else
+    if isa(alg.engine, Stan.Static)   # hmcda
+      sample(mf, HMCDA(num_samples, num_warmup, adapt.delta, alg.engine.int_time))
+    elseif isa(alg.engine, Stan.Nuts) # nuts
+      sample(mf, NUTS(num_samples, num_warmup, adapt.delta))
+    end
+  end
+end

--- a/src/samplers/support/stan-interface.jl
+++ b/src/samplers/support/stan-interface.jl
@@ -17,6 +17,9 @@ sample{T<:Function}(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool,
   sample(mf, num_samples, num_warmup, save_warmup, thin, ss.adapt, ss.alg)
 
 sample{T<:Function}(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool, thin::Int, adapt::Stan.Adapt, alg::Stan.Hmc) = begin
+  if alg.stepsize_jitter != 0
+    error("[Turing.sample] Turing does not support adding noise to stepsize yet.")
+  end
   if adapt.engaged == false
     if isa(alg.engine, Stan.Static)   # hmc
       stepnum = Int(round(alg.engine.int_time / alg.stepsize))
@@ -28,7 +31,11 @@ sample{T<:Function}(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool,
     if isa(alg.engine, Stan.Static)   # hmcda
       sample(mf, HMCDA(num_samples, num_warmup, adapt.delta, alg.engine.int_time); adapt_conf=adapt)
     elseif isa(alg.engine, Stan.Nuts) # nuts
-      sample(mf, NUTS(num_samples, num_warmup, adapt.delta); adapt_conf=adapt)
+      if alg.metric == Stan.dense_e
+        sample(mf, NUTS(num_samples, num_warmup, adapt.delta); adapt_conf=adapt)
+      else
+        error("[Turing.sample] Turing does not support full covariance matrix for pre-conditioning yet.")
+      end
     end
   end
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 UnicodePlots
 Stats
+Stan

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,2 @@
 UnicodePlots
 Stats
-Stan

--- a/test/stan-interface.jl/stan-interface.jl
+++ b/test/stan-interface.jl/stan-interface.jl
@@ -1,0 +1,13 @@
+using Turing, Stan
+
+@model gdemo(x) = begin
+  s ~ InverseGamma(2,3)
+  m ~ Normal(0,sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
+  return s, m
+end
+
+model_f = gdemo([1.5, 2.0])
+
+chn = sample(model_f, 2000, 1000, false, 1, Stan.Adapt(), Stan.Hmc())


### PR DESCRIPTION
Targeting https://github.com/yebai/Turing.jl/issues/326

Work in progress
- [x] Initial support of Stan interface
  - support `sample{T<:Function}(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool, thin::Int, adapt::Stan.Adapt, alg::Stan.Hmc)`
- [x] Make parameters of adaptation no more constant
- [x] Warn user when setting unsupported settings in Turing
- [x] Use Stan's adaptation settings