### PR TITLE
remove trailing dollar signs in makefile

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -5,8 +5,8 @@ CXXFLAGS += $(shell julia $(JL_SHARE)/julia-config.jl --cflags)
 LDFLAGS  += $(shell julia $(JL_SHARE)/julia-config.jl --ldflags)
 LDLIBS   += $(shell julia $(JL_SHARE)/julia-config.jl --ldlibs)
 
-CFLAGS   += $(shell julia -e 'print("-std=gnu99 ")')$
-CFLAGS   += $(shell julia -e 'if is_windows() && Int == Int32 print("-march=pentium4 ") end')$
+CFLAGS   += $(shell julia -e 'print("-std=gnu99 ")')
+CFLAGS   += $(shell julia -e 'if is_windows() && Int == Int32 print("-march=pentium4 ") end')
 
 task: task.c
 	$(CC) $(CFLAGS) -O2 -shared -fPIC task.c $(LDFLAGS) $(LDLIBS) -o libtask.$(LIBEXT)


### PR DESCRIPTION
I'm not sure what the `$` at the end of the line are doing here or why these work elsewhere but produce an error on my system (GNU make 4.2.1 on Archlinux), but `Pkg.build` fails without this change (on 0.5 and 0.6). 

Fixes #348 