### PR TITLE
PIMH sampler

### DIFF
--- a/test/pmmh.jl/pmmh.jl
+++ b/test/pmmh.jl/pmmh.jl
@@ -16,12 +16,20 @@ x = [1.5 2.0]
   s, m
 end
 
+# PMMH with Gaussian proposal
 check_numerical(
   sample(pmmhtest(x), PMMH(100, SMC(30, :m), (:s, (s) -> Normal(s, sqrt(10))))),
   [:s, :m], [49/24, 7/6]
 )
 
+# PMMH with prior as proposal
 check_numerical(
   sample(pmmhtest(x), PMMH(100, SMC(30, :m), :s)),
+  [:s, :m], [49/24, 7/6]
+)
+
+# PIMH
+check_numerical(
+  sample(pmmhtest(x), PMMH(100, SMC(30))),
   [:s, :m], [49/24, 7/6]
 )

--- a/test/pmmh.jl/pmmh_cons.jl
+++ b/test/pmmh.jl/pmmh_cons.jl
@@ -1,5 +1,6 @@
 using Turing, Distributions
 using Base.Test
+include("../utility.jl")
 
 @model gdemo() = begin
   s ~ InverseGamma(2,3)
@@ -10,11 +11,15 @@ using Base.Test
 end
 
 N = 500
-s1 = PMMH(N, SMC(10, :s), :m)
+s1 = PMMH(N, SMC(10, :s), (:m, (s) -> Normal(s, sqrt(3.0))))
+s2 = PMMH(N, SMC(10, :s), :m)
+s3 = PMMH(N, SMC(10)) # PIMH
 
 c1 = sample(gdemo(), s1)
+c2 = sample(gdemo(), s2)
+c3 = sample(gdemo(), s3)
 
 # Very loose bound, only for testing constructor.
-for c in [c1]
+for c in [c1, c2, c3]
   check_numerical(c, [:s, :m], [49/24, 7/6], eps=1.0)
 end


### PR DESCRIPTION
See issue https://github.com/yebai/Turing.jl/issues/332

This PR allows to use the `PMMH` sampler as a `PIMH` sampler.
As a reminder, PMMH targets p(theta, x_{1:T} | y_{1:T}) whereas PIMH targets p(x_{1:T} | y_{1:T}) (global parameters theta are considered as deterministic and fixed).
See the [PMCMC paper](http://www.stats.ox.ac.uk/~doucet/andrieu_doucet_holenstein_PMCMC.pdf) for reference.

Currently, a PMMH sampler is constructed as :`pmmh = PMMH(N, SMC(10, :s), :m)`.
Now, a PIMH sampler can be built as: `pimh = PMMH(N, SMC(10))`.

Do you think that the syntax is clear enough ?

Best,
Emile