### PR TITLE
ESS computation: remove useless numerator 

### DIFF
--- a/src/core/container.jl
+++ b/src/core/container.jl
@@ -135,7 +135,7 @@ end
 
 function effectiveSampleSize(pc :: ParticleContainer)
   Ws, _ = weights(pc)
-  ess = sum(Ws) ^ 2 / sum(Ws .^ 2)
+  ess = 1.0 / sum(Ws .^ 2) # sum(Ws) ^ 2 = 1.0, because weights are normalised
 end
 
 increase_logweight(pc :: ParticleContainer, t :: Int, logw :: Float64) =


### PR DESCRIPTION
See issue https://github.com/yebai/Turing.jl/issues/350

Current implementation of `effectiveSampleSize ` is
```julia
function effectiveSampleSize(pc :: ParticleContainer)
  Ws, _ = weights(pc)
  ess = sum(Ws) ^ 2 / sum(Ws .^ 2)
end
```

Weights are already normalised consequently `sum(Ws) ^ 2 = 1.0` .

Best,
Emile