### PR TITLE
PIMH & bugfix with PMMH

### DIFF
--- a/src/samplers/pmmh.jl
+++ b/src/samplers/pmmh.jl
@@ -92,10 +92,6 @@ step(model::Function, spl::Sampler{PMMH}, vi::VarInfo, is_first::Bool) = begin
   dprintln(2, "decide wether to accept...")
   if log(rand()) < α             # accepted
     ## pick a particle to be retained.
-    Ws, _ = weights(particles)
-    indx = randcat(Ws)
-    vi = particles[indx].vi
-
     push!(spl.info[:accept_his], true)
     spl.info[:old_likelihood_estimator] = smc_spl.info[:logevidence][end]
     spl.info[:old_prior_prob] = spl.info[:new_prior_prob]

--- a/src/samplers/pmmh.jl
+++ b/src/samplers/pmmh.jl
@@ -70,15 +70,13 @@ step(model::Function, spl::Sampler{PMMH}, vi::VarInfo, is_first::Bool) = begin
   if !isempty(spl.alg.space)
     old_θ = copy(vi[spl])
 
-    for _ = 1:local_spl.alg.n_iters
-      vi = model(vi=vi, sampler=spl)
+    vi = model(vi=vi, sampler=spl)
 
-      if spl.info[:violating_support]
-        dprintln(2, "Early rejection, proposal is outside support...")
-        push!(spl.info[:accept_his], false)
-        vi[spl] = old_θ
-        return vi
-      end
+    if spl.info[:violating_support]
+      dprintln(2, "Early rejection, proposal is outside support...")
+      push!(spl.info[:accept_his], false)
+      vi[spl] = old_θ
+      return vi
     end
   end
 

--- a/test/pmmh.jl/pmmh.jl
+++ b/test/pmmh.jl/pmmh.jl
@@ -16,12 +16,20 @@ x = [1.5 2.0]
   s, m
 end
 
+# PMMH with Gaussian proposal
 check_numerical(
   sample(pmmhtest(x), PMMH(100, SMC(30, :m), (:s, (s) -> Normal(s, sqrt(10))))),
   [:s, :m], [49/24, 7/6]
 )
 
+# PMMH with prior as proposal
 check_numerical(
   sample(pmmhtest(x), PMMH(100, SMC(30, :m), :s)),
+  [:s, :m], [49/24, 7/6]
+)
+
+# PIMH
+check_numerical(
+  sample(pmmhtest(x), PMMH(100, SMC(30))),
   [:s, :m], [49/24, 7/6]
 )

--- a/test/pmmh.jl/pmmh_cons.jl
+++ b/test/pmmh.jl/pmmh_cons.jl
@@ -1,5 +1,6 @@
 using Turing, Distributions
 using Base.Test
+include("../utility.jl")
 
 @model gdemo() = begin
   s ~ InverseGamma(2,3)
@@ -10,11 +11,15 @@ using Base.Test
 end
 
 N = 500
-s1 = PMMH(N, SMC(10, :s), :m)
+s1 = PMMH(N, SMC(10, :s), (:m, (s) -> Normal(s, sqrt(3.0))))
+s2 = PMMH(N, SMC(10, :s), :m)
+s3 = PMMH(N, SMC(10)) # PIMH
 
 c1 = sample(gdemo(), s1)
+c2 = sample(gdemo(), s2)
+c3 = sample(gdemo(), s3)
 
 # Very loose bound, only for testing constructor.
-for c in [c1]
+for c in [c1, c2, c3]
   check_numerical(c, [:s, :m], [49/24, 7/6], eps=1.0)
 end


### PR DESCRIPTION
Fix PPMH https://github.com/yebai/Turing.jl/issues/332 using wrong log model evidence.

Now `PMMH` can also be used as a `PIMH` sampler with the syntax: 
```julia
pimh = PMMH(100, SMC(30)) # new syntax for PIMH
pmmh = PMMH(100, SMC(30, :m), :s) # current syntax for PMMH
```

Best,
Emile