### PR TITLE
Remove display from trace.jl (#353)

### DIFF
--- a/src/trace/tarray.jl
+++ b/src/trace/tarray.jl
@@ -104,7 +104,6 @@ end
 
 
 Base.show(io::IO, S::TArray) = Base.show(io::IO, task_local_storage(S.ref)[2])
-Base.display(io::IO, S::TArray) = Base.display(io::IO, task_local_storage(S.ref)[2])
 Base.size(S::TArray) = Base.size(task_local_storage(S.ref)[2])
 Base.ndims(S::TArray) = Base.ndims(task_local_storage(S.ref)[2])
 

--- a/test/io.jl/save_resume_chain.jl
+++ b/test/io.jl/save_resume_chain.jl
@@ -3,6 +3,8 @@ using Base.Test
 
 include("../utility.jl")
 
+srand(125)
+
 alg1 = HMCDA(3000, 1000, 0.65, 0.15)
 alg2 = PG(20, 500)
 alg3 = Gibbs(500, PG(30, 10, :s), HMCDA(1, 500, 0.65, 0.05, :m))


### PR DESCRIPTION
The only display function I found is in the trace.jl. I simply removed it and didn't see any error thrown.