### PR TITLE
Random variables which can be sampled in a random order

### DIFF
--- a/src/core/container.jl
+++ b/src/core/container.jl
@@ -37,21 +37,7 @@ function Base.push!(pc :: ParticleContainer, p :: Particle)
 end
 Base.push!(pc :: ParticleContainer) = Base.push!(pc, eltype(pc.vals)(pc.model))
 
-# NOTE: Function to remove.
-# function Base.push!(pc :: ParticleContainer, n :: Int)
-#   vals = Array{eltype(pc.vals), 1}(n)
-#   logWs = Array{eltype(pc.logWs), 1}(n)
-#   for i=1:n
-#     vals[i]  = eltype(pc.vals)(pc.model)
-#     logWs[i] = 0
-#   end
-#   append!(pc.vals, vals)
-#   append!(pc.logWs, logWs)
-#   pc.num_particles += n
-#   pc
-# end
-
-function Base.push!(pc :: ParticleContainer, n :: Int, spl, varInfo)
+function Base.push!(pc :: ParticleContainer, n :: Int, spl :: Sampler, varInfo :: VarInfo)
   vals = Array{eltype(pc.vals), 1}(n)
   logWs = Array{eltype(pc.logWs), 1}(n)
   for i=1:n

--- a/src/core/container.jl
+++ b/src/core/container.jl
@@ -166,10 +166,11 @@ function resample!( pc :: ParticleContainer,
   num_children = zeros(Int,n1)
   map(i->num_children[i]+=1, indx)
   for i = 1:n1
-    p = particles[i] == ref ? ffork(particles[i]) : particles[i]
+    is_ref = particles[i] == ref
+    p = is_ref ? ffork(particles[i], is_ref) : particles[i]
     num_children[i] > 0 && push!(pc, p)
     for k=1:num_children[i]-1
-      newp = ffork(p)
+      newp = ffork(p, is_ref)
       push!(pc, newp)
     end
   end

--- a/src/core/container.jl
+++ b/src/core/container.jl
@@ -149,12 +149,9 @@ increase_logevidence(pc :: ParticleContainer, logw :: Float64) =
 
 function resample!( pc :: ParticleContainer,
                    randcat :: Function = Turing.resampleSystematic,
-                   ref :: Union{Particle, Void} = nothing;
-                   use_replay = false)
+                   ref :: Union{Particle, Void} = nothing)
   n1, particles = pc.num_particles, collect(pc)
   @assert n1 == length(particles)
-
-  ffork = use_replay ?  Traces.fork :  Traces.forkc
 
   # resample
   Ws, _ = weights(pc)
@@ -167,10 +164,10 @@ function resample!( pc :: ParticleContainer,
   map(i->num_children[i]+=1, indx)
   for i = 1:n1
     is_ref = particles[i] == ref
-    p = is_ref ? ffork(particles[i], is_ref) : particles[i]
+    p = is_ref ? Traces.forkc(particles[i], is_ref) : particles[i]
     num_children[i] > 0 && push!(pc, p)
     for k=1:num_children[i]-1
-      newp = ffork(p, is_ref)
+      newp = Traces.forkc(p, is_ref)
       push!(pc, newp)
     end
   end

--- a/src/core/container.jl
+++ b/src/core/container.jl
@@ -77,7 +77,7 @@ function Base.copy(pc :: ParticleContainer)
   particles = collect(pc)
   newpc     = similar(pc)
   for p in particles
-    newp = forkc(p)
+    newp = fork(p)
     push!(newpc, newp)
   end
   newpc.logE        = pc.logE
@@ -164,10 +164,10 @@ function resample!( pc :: ParticleContainer,
   map(i->num_children[i]+=1, indx)
   for i = 1:n1
     is_ref = particles[i] == ref
-    p = is_ref ? Traces.forkc(particles[i], is_ref) : particles[i]
+    p = is_ref ? Traces.fork(particles[i], is_ref) : particles[i]
     num_children[i] > 0 && push!(pc, p)
     for k=1:num_children[i]-1
-      newp = Traces.forkc(p, is_ref)
+      newp = Traces.fork(p, is_ref)
       push!(pc, newp)
     end
   end

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -208,11 +208,11 @@ push!(vi::VarInfo, vn::VarName, r::Any, dist::Distributions.Distribution, gid::I
   vi
 end
 
-addindex!(vi::VarInfo, vn::VarName) = begin
-  if haskey(vi.indices, vi.num_produce)
-    push!(vi.indices[vi.num_produce], vn)
+addindex!(vi::VarInfo, vn::VarName, index::Int) = begin
+  if haskey(vi.indices, index)
+    push!(vi.indices[index], vn)
   else
-    vi.indices[vi.num_produce] = [vn]
+    vi.indices[index] = [vn]
   end
 
   vi

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -41,8 +41,7 @@ type VarInfo
   pred        ::    Dict{Symbol,Any}
   index       ::    Int           # index of current randomness
   num_produce ::    Int           # num of produce calls from trace, each produce corresponds to an observe.
-  indices     ::    Dict{Int,Vector{VarName}}     # indices of current randomness
-  orders      ::    Vector{Int}     #
+  orders      ::    Vector{Int}   #
   VarInfo() = begin
     vals = Vector{Vector{Real}}(); push!(vals, Vector{Real}())
     trans = Vector{Vector{Real}}(); push!(trans, Vector{Real}())
@@ -60,7 +59,6 @@ type VarInfo
       pred,
       0,
       0,
-      Dict{Int,Vector{VarName}}(),
       Vector{Int}()
     )
   end

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -41,7 +41,7 @@ type VarInfo
   pred        ::    Dict{Symbol,Any}
   index       ::    Int           # index of current randomness
   num_produce ::    Int           # num of produce calls from trace, each produce corresponds to an observe.
-  orders      ::    Vector{Int}   #
+  orders      ::    Vector{Int}   # observe statements number associated with random variables
   VarInfo() = begin
     vals = Vector{Vector{Real}}(); push!(vals, Vector{Real}())
     trans = Vector{Vector{Real}}(); push!(trans, Vector{Real}())

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -306,23 +306,23 @@ end
 # end
 
 getretain(vi::VarInfo, n_retain::Int, spl::Union{Void, Sampler}) = begin
-    println("n_retain: ", n_retain)
-    println("vi.num_produce: ", vi.num_produce)
-    println("vi.indices: ", vi.indices)
-  if n_retain == 0
-    gidcs = getidcs(vi, spl)
+  gidcs = getidcs(vi, spl)
+  if vi.num_produce == 0
     res = UnitRange[map(i -> vi.ranges[gidcs[i]], length(gidcs):-1:1)...]
-  elseif haskey(vi.indices, vi.num_produce)
-    vns = Array{VarName}()
-    for
-      vns = vcat(vns, )
+  elseif vi.num_produce < maximum(keys(vi.indices))
+    vns = Vector{VarName}()
+    for idx in vi.num_produce+1:maximum(keys(vi.indices))
+      for vn in vi.indices[idx]
+        if vi.idcs[vn] in gidcs
+          push!(vns, vn)
+        end
+      end
     end
-    vns = [vi.indices[idx] for idx in 1:vi.num_produce-1]
     res = UnitRange[vi.ranges[vi.idcs[vn]] for vn in vns]
   else
     res = UnitRange[]
   end
-  println("res: ", res)
+
   res
 end
 

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -41,6 +41,7 @@ type VarInfo
   pred        ::    Dict{Symbol,Any}
   index       ::    Int           # index of current randomness
   num_produce ::    Int           # num of produce calls from trace, each produce corresponds to an observe.
+  indices     ::    Dict{Int,Vector{VarName}}     # indices of current randomness
   VarInfo() = begin
     vals = Vector{Vector{Real}}(); push!(vals, Vector{Real}())
     trans = Vector{Vector{Real}}(); push!(trans, Vector{Real}())
@@ -57,7 +58,8 @@ type VarInfo
       trans, logp,
       pred,
       0,
-      0
+      0,
+      Dict{Int,Vector{VarName}}()
     )
   end
 end
@@ -206,6 +208,16 @@ push!(vi::VarInfo, vn::VarName, r::Any, dist::Distributions.Distribution, gid::I
   vi
 end
 
+addindex!(vi::VarInfo, vn::VarName) = begin
+  if haskey(vi.indices, vi.num_produce)
+    push!(vi.indices[vi.num_produce], vn)
+  else
+    vi.indices[vi.num_produce] = [vn]
+  end
+
+  vi
+end
+
 # This method is use to generate a new VarName with the right count
 VarName(vi::VarInfo, csym::Symbol, sym::Symbol, indexing::String) = begin
   # TODO: update this method when implementing the sanity check
@@ -288,9 +300,30 @@ getranges(vi::VarInfo, spl::Sampler) = begin
   end
 end
 
+# getretain(vi::VarInfo, n_retain::Int, spl::Union{Void, Sampler}) = begin
+#   gidcs = getidcs(vi, spl)
+#   UnitRange[map(i -> vi.ranges[gidcs[i]], length(gidcs):-1:(n_retain + 1))...]
+# end
+
 getretain(vi::VarInfo, n_retain::Int, spl::Union{Void, Sampler}) = begin
-  gidcs = getidcs(vi, spl)
-  UnitRange[map(i -> vi.ranges[gidcs[i]], length(gidcs):-1:(n_retain + 1))...]
+    println("n_retain: ", n_retain)
+    println("vi.num_produce: ", vi.num_produce)
+    println("vi.indices: ", vi.indices)
+  if n_retain == 0
+    gidcs = getidcs(vi, spl)
+    res = UnitRange[map(i -> vi.ranges[gidcs[i]], length(gidcs):-1:1)...]
+  elseif haskey(vi.indices, vi.num_produce)
+    vns = Array{VarName}()
+    for
+      vns = vcat(vns, )
+    end
+    vns = [vi.indices[idx] for idx in 1:vi.num_produce-1]
+    res = UnitRange[vi.ranges[vi.idcs[vn]] for vn in vns]
+  else
+    res = UnitRange[]
+  end
+  println("res: ", res)
+  res
 end
 
 #######################################

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -202,12 +202,8 @@ push!(vi::VarInfo, vn::VarName, r::Any, dist::Distributions.Distribution, gid::I
   push!(vi.dists, dist)
   push!(vi.gids, gid)
   push!(vi.trans[end], false)
+  push!(vi.orders, vi.num_produce)
 
-  vi
-end
-
-addorder!(vi::VarInfo, vn::VarName, num_produce::Int) = begin
-  push!(vi.orders, num_produce)
   vi
 end
 

--- a/src/core/varinfo.jl
+++ b/src/core/varinfo.jl
@@ -39,7 +39,6 @@ type VarInfo
   trans       ::    Vector{Vector{Bool}}
   logp        ::    Vector{Real}
   pred        ::    Dict{Symbol,Any}
-  index       ::    Int           # index of current randomness
   num_produce ::    Int           # num of produce calls from trace, each produce corresponds to an observe.
   orders      ::    Vector{Int}   # observe statements number associated with random variables
   VarInfo() = begin
@@ -57,7 +56,6 @@ type VarInfo
       Vector{Int}(),
       trans, logp,
       pred,
-      0,
       0,
       Vector{Int}()
     )
@@ -183,7 +181,6 @@ Base.show(io::IO, vi::VarInfo) = begin
   | Trans?    :   $(vi.trans)
   | Orders    :   $(vi.orders)
   | Logp      :   $(vi.logp)
-  | Index     :   $(vi.index)
   | #produce  :   $(vi.num_produce)
   \\=======================================================================
   """
@@ -319,13 +316,6 @@ end
 
 # Check if a vn is set to NULL
 isnan(vi::VarInfo, vn::VarName) = any(isnan.(getval(vi, vn)))
-
-# Sanity check for VarInfo.index
-checkindex(vn::VarName, vi::VarInfo) = checkindex(vn, vi, nothing)
-checkindex(vn::VarName, vi::VarInfo, spl::Union{Void, Sampler}) = begin
-  vn_index = getvns(vi, spl)[vi.index]
-  @assert vn_index == vn " sanity check for VarInfo.index failed: vn_index=$vn_index, vi.index=$(vi.index), vn_now=$(vn)"
-end
 
 updategid!(vi::VarInfo, vn::VarName, spl::Sampler) = begin
   if ~isempty(spl.alg.space) && getgid(vi, vn) == 0 && getsym(vi, vn) in spl.alg.space

--- a/src/samplers/ipmcmc.jl
+++ b/src/samplers/ipmcmc.jl
@@ -68,6 +68,7 @@ step(model::Function, spl::Sampler{IPMCMC}, VarInfos::Array{VarInfo}, is_first::
 
   # Run SMC & CSMC nodes
   for j in 1:spl.alg.n_nodes
+    VarInfos[j].num_produce = 0
     VarInfos[j] = step(model, spl.info[:samplers][j], VarInfos[j])
     log_zs[j] = spl.info[:samplers][j].info[:logevidence][end]
   end

--- a/src/samplers/mh.jl
+++ b/src/samplers/mh.jl
@@ -174,7 +174,6 @@ end
 
 assume(spl::Sampler{MH}, dist::Distribution, vn::VarName, vi::VarInfo) = begin
     if isempty(spl.alg.space) || vn.sym in spl.alg.space
-      vi.index += 1
       if ~haskey(vi, vn) error("[MH] does not handle stochastic existence yet") end
       old_val = vi[vn]
 

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -154,6 +154,7 @@ assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::Va
       r = rand(dist)
       setval!(vi, vectorize(dist, r), vn)
       setgid!(vi, spl.alg.gid, vn)
+      setindex!(vi, vn, vi.num_produce)
       r
     else
       checkindex(vn, vi, spl)

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -52,7 +52,7 @@ step(model::Function, spl::Sampler{PG}, vi::VarInfo, _::Bool) = step(model, spl,
 step(model::Function, spl::Sampler{PG}, vi::VarInfo) = begin
   particles = ParticleContainer{TraceR}(model)
 
-  vi.index = 0; vi.num_produce = 0;  # We need this line cause fork2 deepcopy `vi`.
+  vi.num_produce = 0;  # We need this line cause fork2 deepcopy `vi`.
   ref_particle = isempty(vi) ?
                  nothing :
                  fork2(TraceR(model, spl, vi))
@@ -143,7 +143,6 @@ end
 assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::VarInfo) = begin
   vi = current_trace().vi
   if isempty(spl.alg.space) || vn.sym in spl.alg.space
-    vi.index += 1
     if ~haskey(vi, vn)
       r = rand(dist)
       push!(vi, vn, r, dist, spl.alg.gid)
@@ -157,7 +156,6 @@ assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::Va
       setorder!(vi, vn, vi.num_produce)
       r
     else
-      checkindex(vn, vi, spl)
       updategid!(vi, vn, spl)
       vi[vn]
     end

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -147,7 +147,7 @@ assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::Va
     if ~haskey(vi, vn)
       r = rand(dist)
       push!(vi, vn, r, dist, spl.alg.gid)
-      addindex!(vi, vn)
+      addindex!(vi, vn, vi.num_produce)
       spl.info[:cache_updated] = CACHERESET # sanity flag mask for getidcs and getranges
       r
     elseif isnan(vi, vn)

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -147,6 +147,7 @@ assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::Va
     if ~haskey(vi, vn)
       r = rand(dist)
       push!(vi, vn, r, dist, spl.alg.gid)
+      addindex!(vi, vn)
       spl.info[:cache_updated] = CACHERESET # sanity flag mask for getidcs and getranges
       r
     elseif isnan(vi, vn)

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -50,12 +50,12 @@ end
 step(model::Function, spl::Sampler{PG}, vi::VarInfo, _::Bool) = step(model, spl, vi)
 
 step(model::Function, spl::Sampler{PG}, vi::VarInfo) = begin
-  particles = ParticleContainer{TraceR}(model)
+  particles = ParticleContainer{Trace}(model)
 
-  vi.num_produce = 0;  # We need this line cause fork deepcopy `vi`.
+  vi.num_produce = 0;  # Reset num_produce before new sweep\.
   ref_particle = isempty(vi) ?
                  nothing :
-                 fork(TraceR(model, spl, vi))
+                 forkr(Trace(model, spl, vi))
 
   vi[getretain(vi, spl)] = NULL
   resetlogp!(vi)
@@ -68,7 +68,7 @@ step(model::Function, spl::Sampler{PG}, vi::VarInfo) = begin
   end
 
   while consume(particles) != Val{:done}
-    # TODO: forkc somehow cause ProgressMeter to broke - need to figure out why
+    # TODO: fork somehow cause ProgressMeter to broke - need to figure out why
     resample!(particles, spl.alg.resampler, ref_particle)
   end
 

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -57,7 +57,7 @@ step(model::Function, spl::Sampler{PG}, vi::VarInfo) = begin
                  nothing :
                  fork2(TraceR(model, spl, vi))
 
-  vi[getretain(vi, 0, spl)] = NULL
+  vi[getretain(vi, spl)] = NULL
   resetlogp!(vi)
 
   if ref_particle == nothing
@@ -147,14 +147,14 @@ assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::Va
     if ~haskey(vi, vn)
       r = rand(dist)
       push!(vi, vn, r, dist, spl.alg.gid)
-      addindex!(vi, vn, vi.num_produce)
+      addorder!(vi, vn, vi.num_produce)
       spl.info[:cache_updated] = CACHERESET # sanity flag mask for getidcs and getranges
       r
     elseif isnan(vi, vn)
       r = rand(dist)
       setval!(vi, vectorize(dist, r), vn)
       setgid!(vi, spl.alg.gid, vn)
-      setindex!(vi, vn, vi.num_produce)
+      setorder!(vi, vn, vi.num_produce)
       r
     else
       checkindex(vn, vi, spl)

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -52,10 +52,10 @@ step(model::Function, spl::Sampler{PG}, vi::VarInfo, _::Bool) = step(model, spl,
 step(model::Function, spl::Sampler{PG}, vi::VarInfo) = begin
   particles = ParticleContainer{TraceR}(model)
 
-  vi.num_produce = 0;  # We need this line cause fork2 deepcopy `vi`.
+  vi.num_produce = 0;  # We need this line cause fork deepcopy `vi`.
   ref_particle = isempty(vi) ?
                  nothing :
-                 fork2(TraceR(model, spl, vi))
+                 fork(TraceR(model, spl, vi))
 
   vi[getretain(vi, spl)] = NULL
   resetlogp!(vi)
@@ -69,7 +69,7 @@ step(model::Function, spl::Sampler{PG}, vi::VarInfo) = begin
 
   while consume(particles) != Val{:done}
     # TODO: forkc somehow cause ProgressMeter to broke - need to figure out why
-    resample!(particles, spl.alg.resampler, ref_particle; use_replay=false)
+    resample!(particles, spl.alg.resampler, ref_particle)
   end
 
   ## pick a particle to be retained.

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -165,6 +165,7 @@ assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::Va
     else
       r = rand(dist)
       push!(vi, vn, r, dist, -1)
+      addorder!(vi, vn, vi.num_produce)
     end
     acclogp!(vi, logpdf_with_trans(dist, r, istrans(vi, vn)))
     r

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -146,7 +146,6 @@ assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::Va
     if ~haskey(vi, vn)
       r = rand(dist)
       push!(vi, vn, r, dist, spl.alg.gid)
-      addorder!(vi, vn, vi.num_produce)
       spl.info[:cache_updated] = CACHERESET # sanity flag mask for getidcs and getranges
       r
     elseif isnan(vi, vn)
@@ -165,7 +164,6 @@ assume{T<:Union{PG,SMC}}(spl::Sampler{T}, dist::Distribution, vn::VarName, _::Va
     else
       r = rand(dist)
       push!(vi, vn, r, dist, -1)
-      addorder!(vi, vn, vi.num_produce)
     end
     acclogp!(vi, logpdf_with_trans(dist, r, istrans(vi, vn)))
     r

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -41,7 +41,6 @@ assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo) = begin
   else
     r = init(dist)
     push!(vi, vn, r, dist, 0)
-    addorder!(vi, vn, vi.num_produce+1)
   end
   # NOTE: The importance weight is not correctly computed here because
   #       r is genereated from some uniform distribution which is different from the prior
@@ -64,14 +63,12 @@ assume{T<:Distribution}(spl::Void, dists::Vector{T}, vn::VarName, var::Any, vi::
     if isa(dist, UnivariateDistribution) || isa(dist, MatrixDistribution)
       for i = 1:n
         push!(vi, vns[i], rs[i], dist, 0)
-        addorder!(vi, vns[i], vi.num_produce+1)
       end
       @assert size(var) == size(rs) "[assume] variable and random number dimension unmatched"
       var = rs
     elseif isa(dist, MultivariateDistribution)
       for i = 1:n
         push!(vi, vns[i], rs[:,i], dist, 0)
-        addorder!(vi, vns[i], vi.num_produce+1)
       end
       if isa(var, Vector)
         @assert length(var) == size(rs)[2] "[assume] variable and random number dimension unmatched"

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -41,6 +41,7 @@ assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo) = begin
   else
     r = init(dist)
     push!(vi, vn, r, dist, 0)
+    addindex!(vi, vn, vi.num_produce+1)
   end
   # NOTE: The importance weight is not correctly computed here because
   #       r is genereated from some uniform distribution which is different from the prior
@@ -89,8 +90,10 @@ assume{T<:Distribution}(spl::Void, dists::Vector{T}, vn::VarName, var::Any, vi::
   var
 end
 
-observe(spl::Void, dist::Distribution, value::Any, vi::VarInfo) =
+observe(spl::Void, dist::Distribution, value::Any, vi::VarInfo) = begin
+  vi.num_produce += 1
   acclogp!(vi, logpdf(dist, value))
+end
 
 observe{T<:Distribution}(spl::Void, dists::Vector{T}, value::Any, vi::VarInfo) = begin
   @assert length(dists) == 1 "[observe] Turing only support vectorizing i.i.d distribution"

--- a/src/samplers/sampler.jl
+++ b/src/samplers/sampler.jl
@@ -41,7 +41,7 @@ assume(spl::Void, dist::Distribution, vn::VarName, vi::VarInfo) = begin
   else
     r = init(dist)
     push!(vi, vn, r, dist, 0)
-    addindex!(vi, vn, vi.num_produce+1)
+    addorder!(vi, vn, vi.num_produce+1)
   end
   # NOTE: The importance weight is not correctly computed here because
   #       r is genereated from some uniform distribution which is different from the prior
@@ -64,12 +64,14 @@ assume{T<:Distribution}(spl::Void, dists::Vector{T}, vn::VarName, var::Any, vi::
     if isa(dist, UnivariateDistribution) || isa(dist, MatrixDistribution)
       for i = 1:n
         push!(vi, vns[i], rs[i], dist, 0)
+        addorder!(vi, vns[i], vi.num_produce+1)
       end
       @assert size(var) == size(rs) "[assume] variable and random number dimension unmatched"
       var = rs
     elseif isa(dist, MultivariateDistribution)
       for i = 1:n
         push!(vi, vns[i], rs[:,i], dist, 0)
+        addorder!(vi, vns[i], vi.num_produce+1)
       end
       if isa(var, Vector)
         @assert length(var) == size(rs)[2] "[assume] variable and random number dimension unmatched"

--- a/src/samplers/smc.jl
+++ b/src/samplers/smc.jl
@@ -52,7 +52,7 @@ step(model::Function, spl::Sampler{SMC}, vi::VarInfo) = begin
     TraceType = spl.alg.use_replay ? TraceR : TraceC
     particles = ParticleContainer{TraceType}(model)
     vi.index = 0; vi.num_produce = 0;  # We need this line cause fork2 deepcopy `vi`.
-    vi[getretain(vi, 0, spl)] = NULL
+    vi[getretain(vi, spl)] = NULL
     resetlogp!(vi)
 
     push!(particles, spl.alg.n_particles, spl, vi)

--- a/src/samplers/smc.jl
+++ b/src/samplers/smc.jl
@@ -51,7 +51,7 @@ end
 step(model::Function, spl::Sampler{SMC}, vi::VarInfo) = begin
     TraceType = spl.alg.use_replay ? TraceR : TraceC
     particles = ParticleContainer{TraceType}(model)
-    vi.index = 0; vi.num_produce = 0;  # We need this line cause fork2 deepcopy `vi`.
+    vi.num_produce = 0;  # We need this line cause fork2 deepcopy `vi`.
     vi[getretain(vi, spl)] = NULL
     resetlogp!(vi)
 

--- a/src/samplers/smc.jl
+++ b/src/samplers/smc.jl
@@ -47,8 +47,8 @@ Sampler(alg::SMC) = begin
 end
 
 step(model::Function, spl::Sampler{SMC}, vi::VarInfo) = begin
-    particles = ParticleContainer{TraceC}(model)
-    vi.num_produce = 0;  # We need this line cause fork deepcopy `vi`.
+    particles = ParticleContainer{Trace}(model)
+    vi.num_produce = 0;  # Reset num_produce before new sweep\.
     vi[getretain(vi, spl)] = NULL
     resetlogp!(vi)
 
@@ -73,7 +73,7 @@ end
 function sample(model::Function, alg::SMC)
   spl = Sampler(alg);
 
-  particles = ParticleContainer{TraceC}(model)
+  particles = ParticleContainer{Trace}(model)
   push!(particles, spl.alg.n_particles, spl, VarInfo())
 
   while consume(particles) != Val{:done}

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -2,7 +2,6 @@ global Δ_max = 1000
 
 runmodel(model::Function, vi::VarInfo, spl::Union{Void,Sampler}) = begin
   dprintln(4, "run model...")
-  vi.index = 0
   setlogp!(vi, zero(Real))
   if spl != nothing spl.info[:total_eval_num] += 1 end
   # model(vi=vi, sampler=spl) # run model

--- a/src/trace/trace.jl
+++ b/src/trace/trace.jl
@@ -83,8 +83,7 @@ function forkc(trace :: Trace, is_ref :: Bool = false)
 
   newtrace.vi = deepcopy(trace.vi)
   if is_ref
-    n_rand = min(trace.vi.index, length(getvns(trace.vi, trace.spl)))
-    newtrace.vi[getretain(newtrace.vi, n_rand, newtrace.spl)] = NULL
+    newtrace.vi[getretain(newtrace.vi, newtrace.spl)] = NULL
   end
 
   newtrace.task.storage[:turing_trace] = newtrace
@@ -108,7 +107,7 @@ function forkr(trace :: TraceR, t :: Int, keep :: Bool)
   # Step 2: Remove remaining randomness if keep==false
   if !keep
     index = newtrace.vi.index
-    newtrace.vi[getretain(newtrace.vi, index, trace.spl)] = NULL
+    newtrace.vi[getretain(newtrace.vi, trace.spl)] = NULL
   end
 
   newtrace

--- a/src/trace/trace.jl
+++ b/src/trace/trace.jl
@@ -59,7 +59,6 @@ function (::Type{Trace{T}}){T}(f::Function, spl::Sampler, vi :: VarInfo)
   res.spl = spl
   # Task(()->f());
   res.vi = deepcopy(vi)
-  res.vi.index = 0
   res.vi.num_produce = 0
   res.task = Task( () -> begin vi_new=f(vi, spl); produce(Val{:done}); vi_new; end )
   if isa(res.task.storage, Void)
@@ -98,7 +97,6 @@ function forkr(trace :: TraceR, t :: Int, keep :: Bool)
   newtrace.spl = trace.spl
 
   newtrace.vi = deepcopy(trace.vi)
-  newtrace.vi.index = 0
   newtrace.vi.num_produce = 0
 
   # Step 1: Call consume t times to replay randomness

--- a/src/trace/trace.jl
+++ b/src/trace/trace.jl
@@ -76,15 +76,17 @@ const TraceC = Trace{:C} # Replay
 Base.consume(t::Trace) = (t.vi.num_produce += 1; Base.consume(t.task))
 
 # Task copying version of fork for both TraceR and TraceC.
-function forkc(trace :: Trace)
+function forkc(trace :: Trace, is_ref :: Bool = false)
   newtrace = typeof(trace)()
   newtrace.task = Base.copy(trace.task)
   newtrace.spl = trace.spl
 
-  n_rand = min(trace.vi.index, length(getvns(trace.vi, trace.spl)))
   newtrace.vi = deepcopy(trace.vi)
+  if is_ref
+    n_rand = min(trace.vi.index, length(getvns(trace.vi, trace.spl)))
+    newtrace.vi[getretain(newtrace.vi, n_rand, newtrace.spl)] = NULL
+  end
 
-  newtrace.vi[getretain(newtrace.vi, n_rand, trace.spl)] = NULL
   newtrace.task.storage[:turing_trace] = newtrace
   newtrace
 end

--- a/src/trace/trace.jl
+++ b/src/trace/trace.jl
@@ -106,7 +106,6 @@ function forkr(trace :: TraceR, t :: Int, keep :: Bool)
 
   # Step 2: Remove remaining randomness if keep==false
   if !keep
-    index = newtrace.vi.index
     newtrace.vi[getretain(newtrace.vi, trace.spl)] = NULL
   end
 

--- a/test/container.jl/copy_particle_container.jl
+++ b/test/container.jl/copy_particle_container.jl
@@ -1,7 +1,7 @@
-using Turing: ParticleContainer, TraceC, copy
+using Turing: ParticleContainer, Trace, copy
 using Base.Test
 
-pc = ParticleContainer{TraceC}(x -> x * x)
+pc = ParticleContainer{Trace}(x -> x * x)
 newpc = copy(pc)
 
 @test newpc.logE        == pc.logE

--- a/test/hmcda.jl/hmcda.jl
+++ b/test/hmcda.jl/hmcda.jl
@@ -1,6 +1,8 @@
 using Turing
 using Base.Test
 
+srand(125)
+
 alg1 = HMCDA(3000, 1000, 0.65, 0.15)
 # alg2 = Gibbs(3000, HMCDA(1, 200, 0.65, 0.35, :m), HMC(1, 0.25, 3, :s))
 alg3 = Gibbs(1500, PG(30, 10, :s), HMCDA(1, 500, 0.65, 0.05, :m))

--- a/test/ipmcmc.jl/ipmcmc.jl
+++ b/test/ipmcmc.jl/ipmcmc.jl
@@ -14,7 +14,7 @@ x = [1.5 2.0]
   s, m
 end
 
-alg = IPMCMC(30, 100, 4)
+alg = IPMCMC(30, 500, 4)
 chain = sample(gdemo(x), alg)
 @test mean(chain[:s]) ≈ 49/24 atol=0.1
 @test mean(chain[:m]) ≈ 7/6 atol=0.1

--- a/test/resample.jl/particlecontainer.jl
+++ b/test/resample.jl/particlecontainer.jl
@@ -3,7 +3,7 @@
 using Turing
 using Distributions
 
-import Turing: ParticleContainer, weights, resample!, effectiveSampleSize, TraceC, TraceR, Trace, current_trace, VarName, Sampler
+import Turing: ParticleContainer, weights, resample!, effectiveSampleSize, Trace, Trace, current_trace, VarName, Sampler
 
 global n = 0
 
@@ -26,11 +26,11 @@ function f()
   end
 end
 
-pc = ParticleContainer{TraceC}(f)
+pc = ParticleContainer{Trace}(f)
 
-push!(pc, TraceC(pc.model))
-push!(pc, TraceC(pc.model))
-push!(pc, TraceC(pc.model))
+push!(pc, Trace(pc.model))
+push!(pc, Trace(pc.model))
+push!(pc, Trace(pc.model))
 
 Base.@assert weights(pc)[1] == [1/3, 1/3, 1/3]
 Base.@assert weights(pc)[2] ≈ log(3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ testcases = Dict(
                           #  "explicit_ret",
                            "new_grammar", "newinterface", "noreturn", "forbid_global",],
         "container.jl" => ["copy_particle_container",],
-        "varinfo.jl"   => ["replay", "test_varname", "varinfo", "is_inside",],
+        "varinfo.jl"   => ["replay", "test_varname", "varinfo", "orders", "is_inside",],
         "io.jl"        => ["chain_utility", "save_resume_chain",],
         "util.jl"      => ["util",],
 #     distributions/

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,8 +44,7 @@ testcases = Dict(
         "mh.jl"    => ["mh_cons", "mh", "mh2",],
         # "pmmh.jl"  => ["pmmh_cons", "pmmh", "pmmh2",],
         "pmmh.jl"  => ["pmmh_cons", "pmmh2",],
-        # "ipmcmc.jl"=> ["ipmcmc_cons", "ipmcmc", "ipmcmc2",],
-        "ipmcmc.jl"=> ["ipmcmc_cons",],
+        "ipmcmc.jl"=> ["ipmcmc_cons", "ipmcmc", "ipmcmc2",],
 #       pgibbs.jl
 #       sampler.jl
 #       smc.jl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,8 @@ testcases = Dict(
         "mh.jl"    => ["mh_cons", "mh", "mh2",],
         # "pmmh.jl"  => ["pmmh_cons", "pmmh", "pmmh2",],
         "pmmh.jl"  => ["pmmh_cons", "pmmh2",],
-        "ipmcmc.jl"=> ["ipmcmc_cons", "ipmcmc", "ipmcmc2",],
+        # "ipmcmc.jl"=> ["ipmcmc_cons", "ipmcmc", "ipmcmc2",],
+        "ipmcmc.jl"=> ["ipmcmc_cons",],
 #       pgibbs.jl
 #       sampler.jl
 #       smc.jl

--- a/test/trace.jl/trace.jl
+++ b/test/trace.jl/trace.jl
@@ -3,7 +3,7 @@
 using Turing
 using Distributions
 
-import Turing: Trace, TraceR, TraceC, current_trace, fork, fork2, VarName, Sampler
+import Turing: Trace, TraceR, TraceC, current_trace, fork, VarName, Sampler
 
 global n = 0
 
@@ -35,20 +35,3 @@ consume(a); consume(a)
 
 Base.@assert consume(t) == 2
 Base.@assert consume(a) == 4
-
-
-# Test replaying version of trace
-t = TraceR(f2)
-
-consume(t); consume(t)
-a = fork(t);
-consume(a); consume(a)
-
-Base.@assert consume(t) == 2
-Base.@assert consume(a) == 4
-
-a2 = fork(t)
-a2_vals = collect(Iterators.filter(x -> ~isnan.(x), a2.vi.vals[end]))
-Base.@assert length(a2_vals) == 5
-Base.@assert t.vi.vals[end] == a2_vals
-Base.@assert t.vi.index == a2.vi.index

--- a/test/trace.jl/trace.jl
+++ b/test/trace.jl/trace.jl
@@ -1,9 +1,9 @@
-# Test TraceC and TraceR
+# Test Trace
 
 using Turing
 using Distributions
 
-import Turing: Trace, TraceR, TraceC, current_trace, fork, VarName, Sampler
+import Turing: Trace, Trace, current_trace, fork, VarName, Sampler
 
 global n = 0
 
@@ -27,7 +27,7 @@ function f2()
 end
 
 # Test task copy version of trace
-t = TraceC(f2)
+t = Trace(f2)
 
 consume(t); consume(t)
 a = fork(t);

--- a/test/varinfo.jl/orders.jl
+++ b/test/varinfo.jl/orders.jl
@@ -1,0 +1,113 @@
+using Turing, Base.Test
+using Turing: uid, cuid, reconstruct, invlink, getvals, step, getidcs, getretain, NULL, CACHERESET
+using Turing: VarInfo, VarName
+
+randr(vi::VarInfo, vn::VarName, dist::Distribution, spl::Turing.Sampler) = begin
+  if ~haskey(vi, vn)
+    r = rand(dist)
+    Turing.push!(vi, vn, r, dist, spl.alg.gid)
+    spl.info[:cache_updated] = CACHERESET
+    r
+  elseif isnan(vi, vn)
+    r = rand(dist)
+    Turing.setval!(vi, Turing.vectorize(dist, r), vn)
+    Turing.setorder!(vi, vn, vi.num_produce)
+    r
+  else
+    Turing.updategid!(vi, vn, spl)
+    vi[vn]
+  end
+end
+
+csym = gensym()
+vn_z1 = VarName(csym, :z, "[1]", 1)
+vn_z2 = VarName(csym, :z, "[2]", 1)
+vn_z3 = VarName(csym, :z, "[3]", 1)
+vn_z4 = VarName(csym, :z, "[4]", 1)
+vn_a1 = VarName(csym, :a, "[1]", 1)
+vn_a2 = VarName(csym, :a, "[2]", 1)
+vn_b = VarName(csym, :b, "", 1)
+
+vi = VarInfo()
+dists = [Categorical([0.7, 0.3]), Normal()]
+
+alg1 = PG(PG(5,5),1)
+spl1 = Turing.Sampler(alg1)
+alg2 = PG(PG(5,5),2)
+spl2 = Turing.Sampler(alg2)
+
+# First iteration, variables are added to vi
+# variables samples in order: z1,a1,z2,a2,z3
+vi.num_produce += 1
+randr(vi, vn_z1, dists[1], spl1)
+randr(vi, vn_a1, dists[2], spl1)
+vi.num_produce += 1
+randr(vi, vn_b, dists[2], spl2)
+randr(vi, vn_z2, dists[1], spl1)
+randr(vi, vn_a2, dists[2], spl1)
+vi.num_produce += 1
+randr(vi, vn_z3, dists[1], spl1)
+@test vi.orders == [1, 1, 2, 2, 2, 3]
+@test vi.num_produce == 3
+@test getretain(vi, spl1) == UnitRange[]
+
+# Check getretain at different stages
+# variables samples in different order: z1,a1,z2,z3,a2
+vi.num_produce = 0
+@test getretain(vi, spl1) == UnitRange[6:6,5:5,4:4,2:2,1:1]
+@test getretain(vi, spl2) == UnitRange[3:3]
+vi[getretain(vi, spl1)] = NULL
+
+vi.num_produce += 1
+randr(vi, vn_z1, dists[1], spl1)
+randr(vi, vn_a1, dists[2], spl1)
+@test getretain(vi, spl1) == UnitRange[4:4,5:5,6:6]
+vi.num_produce += 1
+randr(vi, vn_z2, dists[1], spl1)
+@test getretain(vi, spl1) == UnitRange[6:6]
+vi.num_produce += 1
+randr(vi, vn_z3, dists[1], spl1)
+randr(vi, vn_a2, dists[2], spl1)
+@test vi.orders == [1, 1, 2, 2, 3, 3]
+@test vi.num_produce == 3
+
+# Reference particle replays in same order
+# Check getretain at same stage, and should get different result
+vi_ref = deepcopy(vi)
+vi_ref.num_produce = 0
+vi_ref.num_produce += 1
+randr(vi_ref, vn_z1, dists[1], spl1)
+randr(vi_ref, vn_a1, dists[2], spl1)
+vi_ref.num_produce += 1
+randr(vi_ref, vn_z2, dists[1], spl1)
+@test getretain(vi_ref, spl1) == UnitRange[5:5,6:6]
+vi_ref.num_produce += 1
+randr(vi_ref, vn_z3, dists[1], spl1)
+randr(vi_ref, vn_a2, dists[2], spl1)
+
+# Change order of samples: z1,a1,z2,z3 (no a2 anymore)
+vi = deepcopy(vi_ref)
+vi.num_produce = 0
+vi[getretain(vi, spl1)] = NULL
+vi.num_produce += 1
+randr(vi, vn_z1, dists[1], spl1)
+randr(vi, vn_a1, dists[2], spl1)
+vi.num_produce += 1
+randr(vi, vn_z2, dists[1], spl1)
+vi.num_produce += 1
+randr(vi, vn_z3, dists[1], spl1)
+vi.num_produce += 1
+randr(vi, vn_z4, dists[1], spl1)
+
+# Reference particle replay
+# Check that a2 - not being sampled - does not mess with getretain
+vi_ref = deepcopy(vi)
+vi_ref.num_produce = 0
+vi_ref.num_produce += 1
+randr(vi_ref, vn_z1, dists[1], spl1)
+randr(vi_ref, vn_a1, dists[2], spl1)
+vi_ref.num_produce += 1
+randr(vi_ref, vn_z2, dists[1], spl1)
+vi_ref.num_produce += 1
+randr(vi_ref, vn_z3, dists[1], spl1)
+@test getretain(vi_ref, spl1) == UnitRange[7:7]

--- a/test/varinfo.jl/orders.jl
+++ b/test/varinfo.jl/orders.jl
@@ -2,6 +2,7 @@ using Turing, Base.Test
 using Turing: uid, cuid, reconstruct, invlink, getvals, step, getidcs, getretain, NULL, CACHERESET
 using Turing: VarInfo, VarName
 
+# Mock assume method for CSMC cf src/samplers/pgibbs.jl
 randr(vi::VarInfo, vn::VarName, dist::Distribution, spl::Turing.Sampler) = begin
   if ~haskey(vi, vn)
     r = rand(dist)
@@ -19,7 +20,7 @@ randr(vi::VarInfo, vn::VarName, dist::Distribution, spl::Turing.Sampler) = begin
   end
 end
 
-csym = gensym()
+csym = gensym() # unique per model
 vn_z1 = VarName(csym, :z, "[1]", 1)
 vn_z2 = VarName(csym, :z, "[2]", 1)
 vn_z3 = VarName(csym, :z, "[3]", 1)

--- a/test/varinfo.jl/varinfo.jl
+++ b/test/varinfo.jl/varinfo.jl
@@ -3,7 +3,6 @@ using Turing: uid, cuid, reconstruct, invlink, getvals, step, getidcs, getretain
 using Turing: VarInfo, VarName
 
 randr(vi::VarInfo, vn::VarName, dist::Distribution, spl::Turing.Sampler, count::Bool) = begin
-  vi.index = count ? vi.index + 1 : vi.index
   if ~haskey(vi, vn)
     r = rand(dist)
     Turing.push!(vi, vn, r, dist, spl.alg.gid)

--- a/test/varinfo.jl/varinfo.jl
+++ b/test/varinfo.jl/varinfo.jl
@@ -63,8 +63,8 @@ vn_u = VarName(gensym(), :u, "", 1)
 randr(vi, vn_u, dists[1], spl2, true)
 
 # println(vi)
-
-vi[getretain(vi, 1, spl2)] = NULL
+vi.num_produce = 1
+vi[getretain(vi, spl2)] = NULL
 
 # println(vi)
 


### PR DESCRIPTION
There is a new array `orders :: Vector{Int}` in `VarInfo`, which for each random variable (indexed bu integers via `idcs`) maps the the index of the previous `observe` statement (i.e. `vi.num_produce`).
This array is filled each time a new random variable is encountered (thus just after `push!(vi, vn, r, dist, spl.alg.gid)` is called, we call `addorder!(vi, vn, vi.num_produce)`).

This array is then called in `getretain` so that all/only random variables (belonging to the current sampler) that have been sampled after the current value of `vi.num_produce` are returned.

Furthermore, in non reference particles, when a random variable which needs to be sampled (having a `NaN` value) is encoutared, the `orders` array is updated by calling `setorder!(vi, vn, vi.num_produce)`.