### PR TITLE
Fix MoC bench

### DIFF
--- a/example-models/stan-models/MoC.model.jl
+++ b/example-models/stan-models/MoC.model.jl
@@ -10,10 +10,10 @@
   #  z[m] ~ Categorical(theta)
   #end
 
-  log_theta = log(theta)
+  log_theta = log.(theta)
   Turing.acclogp!(vi, sum(log_theta[z]))
 
-  log_phi = map(x->log(x), phi)
+  log_phi = map(x->log.(x), phi)
   lp = mapreduce(n->log_phi[z[doc[n]]][w[n]], +, 1:N)
   Turing.acclogp!(vi, lp)
 


### PR DESCRIPTION
After fixing this I think all benchmarks reported in the wiki table are alive now.