### PR TITLE
SMC needs to resample at the end

### DIFF
--- a/src/samplers/smc.jl
+++ b/src/samplers/smc.jl
@@ -84,6 +84,7 @@ function sample(model::Function, alg::SMC)
       resample!(particles,spl.alg.resampler,use_replay=spl.alg.use_replay)
     end
   end
+  resample!(particles,spl.alg.resampler,use_replay=spl.alg.use_replay)
   w, samples = getsample(particles)
   res = Chain(w, samples)
 

--- a/test/smc.jl/smc.jl
+++ b/test/smc.jl/smc.jl
@@ -1,0 +1,19 @@
+using Turing
+using Base.Test
+srand(125)
+
+x = [1.5 2.0]
+
+@model smctest(x) = begin
+  s ~ InverseGamma(2,3)
+  m ~ Normal(0,sqrt(s))
+  for i in 1:length(x)
+    x[i] ~ Normal(m, sqrt(s))
+  end
+  s, m
+end
+
+check_numerical(
+  sample(pmmhtest(x), SMC(100)),
+  [:s, :m], [49/24, 7/6]
+)


### PR DESCRIPTION
We need to add a resample statement to the SMC algorithm so that resampling is done at the end of the program.

Without this, any likelihood values from the last `observe` statement are discarded. In extreme cases with one observe statement in the program, this means we are just sampling from the prior 😮 

I also added a test for SMC, like the one we had already for IPMCMC