### PR TITLE
Delete building file if exist

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,5 @@ ReverseDiff
 Mamba
 
 ProgressMeter
+
+BinaryProvider 0.3.0

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,3 @@
-# Delete building file if exists
-if isfile("./deps.jl") rm("./deps.jl") end
-if ispath("./usr") rm("./usr"; recursive=true) end
-
 using BinaryProvider # requires BinaryProvider 0.3.0 or later
 
 # Parse some basic command-line arguments

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,7 @@
+# Delete building file if exists
+if isfile("./deps.jl") rm("./deps.jl") end
+if ispath("./usr") rm("./usr"; recursive=true) end
+
 using BinaryProvider # requires BinaryProvider 0.3.0 or later
 
 # Parse some basic command-line arguments


### PR DESCRIPTION
I found that if the building files exist, I cannot run `Pkg.build("Turing")`. 

Basically it gives me
```julia
julia> Pkg.build("Turing")
INFO: Building Stan
INFO: Building SpecialFunctions
INFO: Building Rmath
INFO: Building Cairo
INFO: Building CodecZlib
INFO: Building Turing
============================================[ ERROR: Turing ]=============================================

LoadError: UndefVarError: isinstalled not defined
while loading /afs/inf.ed.ac.uk/user/s16/s1672897/.julia/v0.6/Turing/deps/build.jl, in expression starting on line 29

==========================================================================================================

=============================================[ BUILD ERRORS ]=============================================

WARNING: Turing had build errors.

 - packages with build errors remain installed in /afs/inf.ed.ac.uk/user/s16/s1672897/.julia/v0.6
 - build the package(s) and all dependencies with `Pkg.build("Turing")`
 - build a single package by running its `deps/build.jl` script

==========================================================================================================
```

I try to delete them before build and then it works. So I guess before building we'd better to check if they exist and delete them if it's the case. Dunno if there other better way to work around this problem?